### PR TITLE
Feat: 로그인, 회원가입, 아이디 찾기 UI 및 바인딩 오류 해결

### DIFF
--- a/ToMyongJi-iOS.xcodeproj/project.pbxproj
+++ b/ToMyongJi-iOS.xcodeproj/project.pbxproj
@@ -28,16 +28,6 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		F51B402C2D226FDD002CBD6C /* Login */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = Login;
-			sourceTree = "<group>";
-		};
-		F53A69462D22A08B002ACC9C /* SignUp */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = SignUp;
-			sourceTree = "<group>";
-		};
 		F56DE3CB2D1819F300319613 /* Intro */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = Intro;
@@ -66,6 +56,11 @@
 		F59C3A172CFB2D11002AD9DA /* Fonts */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = Fonts;
+			sourceTree = "<group>";
+		};
+		F5DA158C2D2BC75400210DB8 /* Authentication */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Authentication;
 			sourceTree = "<group>";
 		};
 		F5DA2A082D01D0C600A51E62 /* CollegeAndClubs */ = {
@@ -129,11 +124,10 @@
 		F59C39ED2CFB1F8E002AD9DA /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				F5DA158C2D2BC75400210DB8 /* Authentication */,
 				F56DE3CB2D1819F300319613 /* Intro */,
 				F5EEE1A52CFC8084009B2270 /* SplashScreen */,
 				F59C39EC2CFB1F8E002AD9DA /* Main */,
-				F53A69462D22A08B002ACC9C /* SignUp */,
-				F51B402C2D226FDD002CBD6C /* Login */,
 				F5DA2A082D01D0C600A51E62 /* CollegeAndClubs */,
 				F59C39FF2CFB22B7002AD9DA /* Receipts */,
 				F59C3A0B2CFB24F9002AD9DA /* Profile */,
@@ -189,14 +183,13 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				F51B402C2D226FDD002CBD6C /* Login */,
-				F53A69462D22A08B002ACC9C /* SignUp */,
 				F56DE3CB2D1819F300319613 /* Intro */,
 				F59C39FF2CFB22B7002AD9DA /* Receipts */,
 				F59C3A072CFB240A002AD9DA /* Shared */,
 				F59C3A082CFB2414002AD9DA /* CoreServices */,
 				F59C3A0B2CFB24F9002AD9DA /* Profile */,
 				F59C3A172CFB2D11002AD9DA /* Fonts */,
+				F5DA158C2D2BC75400210DB8 /* Authentication */,
 				F5DA2A082D01D0C600A51E62 /* CollegeAndClubs */,
 				F5EEE1A52CFC8084009B2270 /* SplashScreen */,
 			);

--- a/ToMyongJi-iOS/Features/Authentication/Login/Models/Login.swift
+++ b/ToMyongJi-iOS/Features/Authentication/Login/Models/Login.swift
@@ -1,0 +1,32 @@
+//
+//  Login.swift
+//  ToMyongJi-iOS
+//
+//  Created by JunKyu Lee on 12/31/24.
+//
+
+import Foundation
+
+struct Login: Codable {
+    let statusCode: Int
+    let statusMessage: String
+    let data: LoginData
+}
+
+struct LoginData: Codable {
+    let grantType: String
+    let accessToken: String
+    let refreshToken: String
+}
+
+struct DecodedAccessToken: Codable {
+    let auth: String // role
+    let exp: Int // token 만료 정보
+    let id: Int // id
+    let sub: String // 로그인하는 id
+}
+
+struct DecodedRefreshToken: Codable {
+    let exp: Int
+}
+

--- a/ToMyongJi-iOS/Features/Authentication/Login/Services/LoginEndpoint.swift
+++ b/ToMyongJi-iOS/Features/Authentication/Login/Services/LoginEndpoint.swift
@@ -1,0 +1,8 @@
+//
+//  LoginEndpoint.swift
+//  ToMyongJi-iOS
+//
+//  Created by JunKyu Lee on 12/31/24.
+//
+
+import Foundation

--- a/ToMyongJi-iOS/Features/Authentication/Login/ViewModels/LoginViewModel.swift
+++ b/ToMyongJi-iOS/Features/Authentication/Login/ViewModels/LoginViewModel.swift
@@ -1,0 +1,14 @@
+//
+//  LoginViewModel.swift
+//  ToMyongJi-iOS
+//
+//  Created by JunKyu Lee on 12/31/24.
+//
+
+import Foundation
+import Combine
+
+@Observable
+class LoginViewModel {
+    
+}

--- a/ToMyongJi-iOS/Features/Authentication/Login/Views/ForgotIDView.swift
+++ b/ToMyongJi-iOS/Features/Authentication/Login/Views/ForgotIDView.swift
@@ -1,5 +1,5 @@
 //
-//  ForgotIdView.swift
+//  ForgotIDView.swift
 //  ToMyongJi-iOS
 //
 //  Created by JunKyu Lee on 30/12/24.
@@ -7,9 +7,8 @@
 
 import SwiftUI
 
-struct ForgotIdView: View {
+struct ForgotIDView: View {
     @Environment(\.dismiss) private var dismiss
-    @Binding var showResetView: Bool
     @State private var emailID: String = ""
     
     var body: some View {
@@ -42,7 +41,6 @@ struct ForgotIdView: View {
                     Task {
                         dismiss()
                         try? await Task.sleep(for: .seconds(0))
-                        showResetView = true
                     }
                 }
                 .hSpacing(.trailing)
@@ -57,5 +55,5 @@ struct ForgotIdView: View {
 }
 
 #Preview {
-    ProfileView()
+    ForgotIDView()
 }

--- a/ToMyongJi-iOS/Features/Authentication/Login/Views/LoginView.swift
+++ b/ToMyongJi-iOS/Features/Authentication/Login/Views/LoginView.swift
@@ -12,7 +12,6 @@ struct LoginView: View {
     @State private var emailID: String = ""
     @State private var password: String = ""
     @State private var showForgotIdView: Bool = false
-    @State private var showResetView: Bool = false
     
     var body: some View {
         VStack(alignment: .leading, spacing: 15) {
@@ -67,18 +66,13 @@ struct LoginView: View {
         .padding(.horizontal, 25)
         .toolbar(.hidden, for: .navigationBar)
         .sheet(isPresented: $showForgotIdView, content: {
-            if #available(iOS 16.4, *) {
-                ForgotIdView(showResetView: $showResetView)
-                    .presentationDetents([.height(300)])
-                    .presentationCornerRadius(30)
-            } else {
-                ForgotIdView(showResetView: $showResetView)
-                    .presentationDetents([.height(300)])
-            }
+            ForgotIDView()
+                .presentationDetents([.height(300)])
+                .presentationCornerRadius(30)
         })
     }
 }
 
 #Preview {
-    ProfileView()
+    LoginView(showSignup: .constant(false))
 }

--- a/ToMyongJi-iOS/Features/Authentication/SignUp/Views/SignUpView.swift
+++ b/ToMyongJi-iOS/Features/Authentication/SignUp/Views/SignUpView.swift
@@ -22,7 +22,7 @@ struct SignUpView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 15) {
             Button(action: {
-                showSignup.toggle()
+                showSignup = false
             }, label: {
                 Image(systemName: "chevron.left")
                     .font(.title3.bold())
@@ -41,7 +41,7 @@ struct SignUpView: View {
                 .padding(.top, -5)
             
             VStack(spacing: 25) {
-                /// 아이디, 비밀번호 텍스트 필드
+                /// 아이디, 비밀번호
                 VStack(spacing: 25) {
                     CustomTF(sfIcon: "person.crop.circle", hint: "아이디", value: $userId)
                     CustomTF(sfIcon: "lock", hint: "비밀번호", isPassword: true, value: $password)
@@ -49,14 +49,19 @@ struct SignUpView: View {
                 }
                 .padding(.bottom, 20)
                 
-                Divider()
-                    .foregroundStyle(Color.softBlue)
-                    .padding(.bottom, 20)
-                
-                /// 이름, 이메일 텍스트 필드
+                /// 이름, 이메일
                 VStack(spacing: 25) {
                     CustomTF(sfIcon: "person", hint: "이름", value: $name)
                     CustomTF(sfIcon: "at", hint: "이메일", value: $email)
+                        .padding(.top, 5)
+                }
+                
+                /// 학번, 대학, 자격, 소속이름
+                VStack(spacing: 25) {
+                    CustomTF(sfIcon: "number", hint: "학번", value: $name)
+                    CustomTF(sfIcon: "building.columns.fill", hint: "대학", value: $name)
+                    CustomTF(sfIcon: "person.badge.key.fill", hint: "자격", value: $name)
+                    CustomTF(sfIcon: "building.2.fill", hint: "소속이름", value: $email)
                         .padding(.top, 5)
                 }
                 
@@ -84,7 +89,7 @@ struct SignUpView: View {
                     .foregroundStyle(.gray)
                 
                 Button("로그인") {
-                    showSignup.toggle()
+                    showSignup = false
                 }
                 .font(.custom("GmarketSansBold", size: 13))
                 .tint(Color.darkNavy)
@@ -98,5 +103,5 @@ struct SignUpView: View {
 }
 
 #Preview {
-    ProfileView()
+    SignUpView(showSignup: .constant(true))
 }

--- a/ToMyongJi-iOS/Features/Authentication/Views/AuthenticationView.swift
+++ b/ToMyongJi-iOS/Features/Authentication/Views/AuthenticationView.swift
@@ -1,0 +1,32 @@
+//
+//  AuthenticationView.swift
+//  ToMyongJi-iOS
+//
+//  Created by JunKyu Lee on 1/6/25.
+//
+
+import SwiftUI
+
+struct AuthenticationView: View {
+    @State private var showSignup: Bool = false
+    @State private var isKeyboardShowing: Bool = false
+    
+    var body: some View {
+        LoginView(showSignup: $showSignup)
+            .fullScreenCover(isPresented: $showSignup) {
+                SignUpView(showSignup: $showSignup)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification), perform: { _ in
+                if !showSignup {
+                    isKeyboardShowing = true
+                }
+            })
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification), perform: { _ in
+                isKeyboardShowing = false
+            })
+    }
+}
+
+#Preview {
+    AuthenticationView()
+}

--- a/ToMyongJi-iOS/Features/Main/Views/MainTabView.swift
+++ b/ToMyongJi-iOS/Features/Main/Views/MainTabView.swift
@@ -26,7 +26,8 @@ struct MainTabView: View {
                 }
                 .tag(2)
             
-            ProfileView()
+//            ProfileView()
+            AuthenticationView()
                 .tabItem {
                     Image(systemName: "person.circle")
                     Text("프로필")

--- a/ToMyongJi-iOS/Features/Profile/Views/ProfileView.swift
+++ b/ToMyongJi-iOS/Features/Profile/Views/ProfileView.swift
@@ -5,43 +5,12 @@
 //  Created by JunKyu Lee on 11/30/24.
 //
 
-//import SwiftUI
-//
-//struct ProfileView: View {
-//    var body: some View {
-//        Text("Profile View")
-//            .font(.custom("GmarketSansMedium", size: 20))
-//    }
-//}
-//
-//#Preview {
-//    ProfileView()
-//}
-
 import SwiftUI
 
 struct ProfileView: View {
-    @State private var showSignup: Bool = false
-    @State private var isKeyboardShowing: Bool = false
-    
     var body: some View {
-        NavigationStack {
-            Group {
-                if showSignup {
-                    SignUpView(showSignup: $showSignup)
-                } else {
-                    LoginView(showSignup: $showSignup)
-                }
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification), perform: { _ in
-            if !showSignup {
-                isKeyboardShowing = true
-            }
-        })
-        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification), perform: { _ in
-            isKeyboardShowing = false
-        })
+        Text("Profile View")
+            .font(.custom("GmarketSansMedium", size: 20))
     }
 }
 

--- a/ToMyongJi-iOS/Shared/Views/GradientButton.swift
+++ b/ToMyongJi-iOS/Shared/Views/GradientButton.swift
@@ -32,5 +32,7 @@ struct GradientButton: View {
 }
 
 #Preview {
-    ProfileView()
+    GradientButton(title: "Button", icon: "arrow.right") {
+            print("Button tapped")
+        }
 }


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #10 

### 📝작업 내용

> 로그인, 회원가입, 아이디 찾기 UI 및 회원가입 -> 로그인 바인딩 오류 해결

<img width="474" alt="image" src="https://github.com/user-attachments/assets/5dbb1c1c-c5ff-4db6-9cea-ce6e72efabb4" />

상태 바인딩 오류를 해결하기 위해 기존에는 상위 뷰에서 NavigationDestination으로 회원가입을 구현한 것을 fullScreenCover로 구현함

### 🔨테스트 결과 > 스크린샷 (선택)

<img width="266" alt="image" src="https://github.com/user-attachments/assets/07024c60-b78e-42e3-ada8-7dcd305c7f87" />



