### PR TITLE
Fix: http 연결 fatal error 수정 - host, port, baseURL 수정

### DIFF
--- a/ToMyongJi-iOS/CoreServices/EndpointEnum.swift
+++ b/ToMyongJi-iOS/CoreServices/EndpointEnum.swift
@@ -25,6 +25,7 @@ extension Endpoint {
         var components = URLComponents()
         components.scheme = "http"
         components.host = self.baseURL
+        components.port = 8080
         components.path = self.path
         if !self.query.isEmpty {
             components.queryItems = self.query.map { URLQueryItem(name: $0, value: $1) }

--- a/ToMyongJi-iOS/Features/CollegeAndClubs/Services/CollegesAndClubsEndpoint.swift
+++ b/ToMyongJi-iOS/Features/CollegeAndClubs/Services/CollegesAndClubsEndpoint.swift
@@ -15,7 +15,7 @@ enum CollegesAndClubsEndpoint {
 extension CollegesAndClubsEndpoint: Endpoint {
     var baseURL: String {
 //        return "api.tomyongji.com"
-        return "http://13.125.66.151:8080"
+        return "13.125.66.151"
     }
     
     var path: String {

--- a/ToMyongJi-iOS/Features/Login/Services/LoginEndpoint.swift
+++ b/ToMyongJi-iOS/Features/Login/Services/LoginEndpoint.swift
@@ -15,7 +15,7 @@ enum LoginEndpoint {
 extension LoginEndpoint: Endpoint {
     var baseURL: String {
 //        return "api.tomyongji.com"
-        return "http://13.125.66.151:8080"
+        return "http://13.125.66.151"
 
     }
     

--- a/ToMyongJi-iOS/Features/Profile/Services/ProfileEndpoint.swift
+++ b/ToMyongJi-iOS/Features/Profile/Services/ProfileEndpoint.swift
@@ -19,7 +19,7 @@ enum ProfileEndpoint {
 extension ProfileEndpoint: Endpoint {
     var baseURL: String {
 //        return "api.tomyongji.com"
-        return "http://13.125.66.151:8080"
+        return "http://13.125.66.151"
     }
     
     var path: String {

--- a/ToMyongJi-iOS/Features/Receipts/Services/ReceiptEndpoint.swift
+++ b/ToMyongJi-iOS/Features/Receipts/Services/ReceiptEndpoint.swift
@@ -15,7 +15,7 @@ enum ReceiptEndpoint {
 extension ReceiptEndpoint: Endpoint {
     var baseURL: String {
 //        return "api.tomyongji.com"
-        return "http://13.125.66.151:8080"
+        return "13.125.66.151"
     }
     
     var path: String {

--- a/ToMyongJi-iOS/Info.plist
+++ b/ToMyongJi-iOS/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>GmarketSansBold.otf</string>


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #30 

### 📝작업 내용

http 연결시 fatal error 발생해서, EndpointEnum의 host, port 수정, 각 기능의 endpoint의 baseURL에서 포트 번호를 삭제

### 🔨테스트 결과 > 스크린샷 (선택)

<img width="639" alt="image" src="https://github.com/user-attachments/assets/4b4831e4-7478-44fa-9f51-7552ac67e9e9" />

<img width="637" alt="image" src="https://github.com/user-attachments/assets/752b1ab3-b3e2-4f44-8ece-11c1a0530a4f" />

<img width="639" alt="image" src="https://github.com/user-attachments/assets/003458cb-2d23-40ca-ab3e-60f1ac811c50" />

<img width="362" alt="image" src="https://github.com/user-attachments/assets/b6b0f60d-3596-41c7-b868-e009cc3233cb" />


