### PR TITLE
Feat: 아이디 중복 체크, 이메일 인증, 소속 인증 api 연결

### DIFF
--- a/ToMyongJi-iOS/Features/Authentication/Views/AuthenticationView.swift
+++ b/ToMyongJi-iOS/Features/Authentication/Views/AuthenticationView.swift
@@ -9,8 +9,9 @@ import SwiftUI
 
 struct AuthenticationView: View {
     @State private var showSignup: Bool = false
+    @State private var showLogin: Bool = true
     @State private var isKeyboardShowing: Bool = false
-    @Bindable private var authManager = AuthenticationManager.shared
+    @State private var authManager = AuthenticationManager.shared
     
     var body: some View {
         Group {

--- a/ToMyongJi-iOS/Features/Login/ViewModels/LoginViewModel.swift
+++ b/ToMyongJi-iOS/Features/Login/ViewModels/LoginViewModel.swift
@@ -52,7 +52,7 @@ class LoginViewModel {
                         accessToken: loginResponse.data.accessToken,
                         decodedToken: decodedToken
                     )
-                    self.alertMessage = "\(decodedToken.sub)님 로그인에 성공했습니다."
+                    self.alertMessage = "로그인에 성공했습니다."
                     self.showAlert = true
                     self.isSuccess = true
                     

--- a/ToMyongJi-iOS/Features/Login/Views/LoginView.swift
+++ b/ToMyongJi-iOS/Features/Login/Views/LoginView.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct LoginView: View {
-    @Bindable private var viewModel = LoginViewModel()
-    @Binding var showSignup: Bool
     @Environment(\.dismiss) private var dismiss
+    @Bindable private var viewModel = LoginViewModel()
     @Bindable private var authManager = AuthenticationManager.shared
+    @Binding var showSignup: Bool
     @State private var showForgotIdView: Bool = false
     
     var body: some View {
@@ -64,9 +64,8 @@ struct LoginView: View {
                     .scaleEffect(1.5)
             }
         }
-        .alert(viewModel.isSuccess ? "로그인 성공" : "로그인 실패", isPresented: $viewModel.showAlert) {
+        .alert(viewModel.isSuccess ? "로그인에 성공했습니다." : "로그인에 실패했습니다.", isPresented: $viewModel.showAlert) {
             Button("확인") {
-                viewModel.showAlert = false
                 if viewModel.isSuccess {
                     dismiss()
                 }

--- a/ToMyongJi-iOS/Features/SignUp/Models/SignUp.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Models/SignUp.swift
@@ -30,6 +30,10 @@ struct EmailRequest: Codable {
     let email: String
 }
 
+struct EmailResponse: Codable {
+    let code: String
+}
+
 struct VerifyCodeRequest: Codable {
     let email: String
     let code: String
@@ -49,6 +53,11 @@ struct UserIdCheckResponse: Codable {
 }
 
 // 소속 인증
+struct Role: Identifiable {
+    let id: String
+    let role: String
+}
+
 struct ClubVerifyRequest: Codable {
     let clubId: Int
     let studentNum: String

--- a/ToMyongJi-iOS/Features/SignUp/Services/SignUpEndpoint.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Services/SignUpEndpoint.swift
@@ -81,6 +81,11 @@ extension SignUpEndpoint: Endpoint {
     }
     
     var encoding: ParameterEncoding {
-        JSONEncoding.default
+        switch self {
+        case .getColleges, .checkUserId:
+            return URLEncoding.default
+        default:
+            return JSONEncoding.default
+        }
     }
 }

--- a/ToMyongJi-iOS/Features/SignUp/ViewModels/SignUpViewModel.swift
+++ b/ToMyongJi-iOS/Features/SignUp/ViewModels/SignUpViewModel.swift
@@ -20,7 +20,7 @@ class SignUpViewModel {
     var studentNum: String = ""
     var selectedCollege: College?
     var selectedClub: Club?
-    var selectedRole: String = "STU"
+    var selectedRole: String = ""
     
     // UI 상태
     var isLoading: Bool = false
@@ -47,9 +47,11 @@ class SignUpViewModel {
                     self?.showAlert(title: "오류", message: error.localizedDescription)
                 }
             } receiveValue: { [weak self] response in
-                self?.isUserIdAvailable = response.data
-                if !response.data {
+                if response.statusCode != 200 {
                     self?.showAlert(title: "알림", message: "이미 사용 중인 아이디입니다.")
+                } else {
+                    self?.showAlert(title: "알림", message: "사용가능한 아이디입니다.")
+                    self?.isUserIdAvailable = true
                 }
             }
             .store(in: &cancellables)
@@ -58,14 +60,10 @@ class SignUpViewModel {
     // 이메일 인증코드 발송
     func sendVerificationEmail() {
         let request = EmailRequest(email: email)
-        networkingManager.run(SignUpEndpoint.sendEmail(request), type: String.self)
-            .sink { [weak self] completion in
-                if case .failure(let error) = completion {
-                    self?.showAlert(title: "오류", message: error.localizedDescription)
-                }
-            } receiveValue: { [weak self] response in
+        networkingManager.run(SignUpEndpoint.sendEmail(request), type: Data.self)
+            .sink { [weak self] _ in
                 self?.showAlert(title: "알림", message: "인증코드가 발송되었습니다.")
-            }
+            } receiveValue: { _ in }
             .store(in: &cancellables)
     }
     

--- a/ToMyongJi-iOS/Features/SignUp/Views/InputClubAuthenticationView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/InputClubAuthenticationView.swift
@@ -8,11 +8,18 @@
 import SwiftUI
 
 struct InputClubAuthenticationView: View {
+    @Environment(\.dismiss) private var dismiss
     @Binding var name: String
     @Binding var studentNum: String
+    @State private var showSignUpAlert: Bool = false
+    
     var viewModel: SignUpViewModel
     var onBack: () -> Void
     var onSignUp: () -> Void
+    var roles: [Role] = [
+        Role(id: "PRESIDENT", role: "회장"),
+        Role(id: "STU", role: "소속원")
+    ]
     
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
@@ -45,6 +52,7 @@ struct InputClubAuthenticationView: View {
                     .font(.custom("GmarketSansLight", size: 15))
                     .foregroundStyle(Color.darkNavy)
                 SignUpTextField(hint: "60221234", value: $studentNum)
+                
                 
                 // 단과대학 선택
                 Menu {
@@ -88,6 +96,30 @@ struct InputClubAuthenticationView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 10))
                     }
                 }
+                
+                // 자격 선택
+                if let club = viewModel.selectedClub {
+                    Menu {
+                        ForEach(roles) { role in
+                            Button(action: {
+                                viewModel.selectedRole = role.id
+                            }) {
+                                Text(role.role)
+                            }
+                        }
+                    } label: {
+                        HStack {
+                            Text(viewModel.selectedRole.isEmpty ? "자격 선택" : roles.first { $0.id == viewModel.selectedRole }?.role ?? "자격 선택")
+                                .font(.custom("GmarketSansLight", size: 15))
+                            Spacer()
+                            Image(systemName: "chevron.down")
+                        }
+                        .foregroundStyle(Color.darkNavy)
+                        .padding()
+                        .background(Color.gray.opacity(0.1))
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                    }
+                }
             }
             
             Spacer()
@@ -109,6 +141,7 @@ struct InputClubAuthenticationView: View {
             // 회원가입 버튼
             Button {
                 onSignUp()
+                showSignUpAlert = true
             } label: {
                 Text("회원가입")
                     .font(.custom("GmarketSansMedium", size: 15))
@@ -121,6 +154,13 @@ struct InputClubAuthenticationView: View {
             .disabled(!viewModel.isClubVerified)
         }
         .padding()
+        .alert("회원가입 완료", isPresented: $showSignUpAlert) {
+            Button("확인") {
+                dismiss()
+            }
+        } message: {
+            Text("회원가입이 완료되었습니다.\n로그인 화면으로 이동합니다.")
+        }
         .onAppear {
             viewModel.fetchColleges()
         }

--- a/ToMyongJi-iOS/Features/SignUp/Views/InputEmailView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/InputEmailView.swift
@@ -53,7 +53,7 @@ struct InputEmailView: View {
                     .foregroundStyle(Color.darkNavy)
                 
                 HStack(spacing: 10) {
-                    SignUpTextField(hint: "example@email.com", value: $email)
+                    SignUpTextField(hint: "tomyongji@gmail.com", value: $email)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
                         .keyboardType(.emailAddress)

--- a/ToMyongJi-iOS/Features/SignUp/Views/InputIDView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/InputIDView.swift
@@ -9,9 +9,17 @@ import SwiftUI
 
 struct InputIDView: View {
     @Binding var userId: String
+    @Binding var isUserIdAvailable: Bool
+
     var onBack: () -> Void
     var onNext: () -> Void
-    @State private var isCheckingId: Bool = false
+    var checkUserId: () -> Void
+    var isValid: Bool {
+        let containsOnlyAllowedCharacters = userId.allSatisfy { char in
+            (char.isLetter && char.isASCII) || char.isNumber
+        }
+        return !userId.isEmpty && containsOnlyAllowedCharacters
+    }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
@@ -39,13 +47,20 @@ struct InputIDView: View {
                 .font(.custom("GmarketSansLight", size: 15))
                 .foregroundStyle(Color.darkNavy)
             HStack(spacing: 10) {
-                SignUpTextField(hint: "sampleID", value: $userId)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
+                SignUpTextField(hint: "아이디를 입력해주세요.", value: Binding(
+                    get: { userId },
+                    set: { newValue in
+                        let filtered = newValue.filter { char in
+                            char.isLetter || char.isNumber
+                        }
+                        userId = filtered
+                    }
+                ))
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
                 
                 Button {
-                    isCheckingId = true
-                    onNext()
+                    checkUserId()
                 } label: {
                     Text("중복 확인")
                         .font(.custom("GmarketSansMedium", size: 13))
@@ -55,7 +70,17 @@ struct InputIDView: View {
                         .background(userId.isEmpty ? Color.gray.opacity(0.3) : Color.softBlue)
                         .clipShape(RoundedRectangle(cornerRadius: 10))
                 }
-                .disabled(userId.isEmpty)
+                .disabled(userId.isEmpty || !isValid)
+            }
+            
+            if !userId.isEmpty {
+                VStack(alignment: .leading, spacing: 5) {
+                    if !userId.allSatisfy({ char in (char.isLetter && char.isASCII) || char.isNumber }) {
+                        Text("• 영어와 숫자만 입력해주세요")
+                            .font(.custom("GmarketSansLight", size: 12))
+                            .foregroundStyle(.red)
+                    }
+                }
             }
             
             Spacer()
@@ -69,9 +94,9 @@ struct InputIDView: View {
             }
             .frame(maxWidth: .infinity, alignment: .center)
             .padding(.vertical, 15)
-            .background((!isCheckingId || userId.isEmpty) ? Color.gray.opacity(0.3) : Color.softBlue)
+            .background((!isValid || !isUserIdAvailable) ? Color.gray.opacity(0.3) : Color.softBlue)
             .clipShape(RoundedRectangle(cornerRadius: 10))
-            .disabled(!isCheckingId || userId.isEmpty)
+            .disabled(!isValid || !isUserIdAvailable)
         }
         .padding()
     }
@@ -79,6 +104,6 @@ struct InputIDView: View {
 
 #Preview {
     NavigationStack {
-        InputIDView(userId: .constant(""), onBack: {}, onNext: {})
+        InputIDView(userId: .constant(""), isUserIdAvailable: .constant(true), onBack: {}, onNext: {}, checkUserId: {})
     }
 }

--- a/ToMyongJi-iOS/Features/SignUp/Views/InputPasswordView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/InputPasswordView.swift
@@ -14,7 +14,15 @@ struct InputPasswordView: View {
     @State private var confirmPassword: String = ""
     
     private var isPasswordValid: Bool {
-        return password.count >= 8 && password == confirmPassword
+        let hasUpperCase = password.contains(where: { $0.isUppercase })
+        let hasNumber = password.contains(where: { $0.isNumber })
+        let hasSpecialCharacter = password.contains(where: { "!@#$%^&*()_+-=[]{}|;:,.<>?".contains($0) })
+        
+        return password.count >= 8 && 
+               password == confirmPassword && 
+               hasUpperCase && 
+               hasNumber && 
+               hasSpecialCharacter
     }
     
     var body: some View {
@@ -43,12 +51,37 @@ struct InputPasswordView: View {
                     .font(.custom("GmarketSansLight", size: 15))
                     .foregroundStyle(Color.darkNavy)
                 SignUpTextField(
-                    hint: "영문, 숫자, 특수문자 포함 8자 이상",
+                    hint: "영문 대소문자, 숫자, 특수문자 포함 8자 이상",
                     isPassword: true,
                     value: $password
                 )
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
+                
+                if !password.isEmpty {
+                    VStack(alignment: .leading, spacing: 5) {
+                        if !password.contains(where: { $0.isUppercase }) {
+                            Text("* 영문 대문자를 포함해주세요")
+                                .font(.custom("GmarketSansLight", size: 12))
+                                .foregroundStyle(.red)
+                        }
+                        if !password.contains(where: { $0.isNumber }) {
+                            Text("* 숫자를 포함해주세요")
+                                .font(.custom("GmarketSansLight", size: 12))
+                                .foregroundStyle(.red)
+                        }
+                        if !password.contains(where: { "!@#$%^&*()_+-=[]{}|;:,.<>?".contains($0) }) {
+                            Text("* 특수문자를 포함해주세요")
+                                .font(.custom("GmarketSansLight", size: 12))
+                                .foregroundStyle(.red)
+                        }
+                        if password.count < 8 {
+                            Text("* 8자 이상 입력해주세요")
+                                .font(.custom("GmarketSansLight", size: 12))
+                                .foregroundStyle(.red)
+                        }
+                    }
+                }
                 
                 Text("비밀번호 확인")
                     .font(.custom("GmarketSansLight", size: 15))

--- a/ToMyongJi-iOS/Features/SignUp/Views/SignUpView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/SignUpView.swift
@@ -28,6 +28,7 @@ struct SignUpView: View {
     @Binding var showSignup: Bool
     @State private var viewModel = SignUpViewModel()
     @State private var currentPage: SignUpPage = .id
+    @State private var keyboardHeight: CGFloat = 0
     
     var body: some View {
         NavigationStack {
@@ -35,14 +36,17 @@ struct SignUpView: View {
             case .id:
                 InputIDView(
                     userId: $viewModel.userId,
+                    isUserIdAvailable: $viewModel.isUserIdAvailable,
                     onBack: { dismiss() },
                     onNext: {
-                        viewModel.checkUserId()
                         if viewModel.isUserIdAvailable {
                             withAnimation {
                                 currentPage = .password
                             }
                         }
+                    },
+                    checkUserId: {
+                        viewModel.checkUserId()
                     }
                 )
             case .password:
@@ -93,7 +97,10 @@ struct SignUpView: View {
                     onSignUp: {
                         viewModel.signUp { success in
                             if success {
-                                showSignup = false
+                                withAnimation {
+                                    dismiss()
+                                    showSignup = false
+                                }
                             }
                         }
                     }
@@ -106,6 +113,7 @@ struct SignUpView: View {
         } message: {
             Text(viewModel.alertMessage)
         }
+        .ignoresSafeArea(.keyboard)
     }
 }
 

--- a/ToMyongJi-iOS/Features/SplashScreen/Views/SplashScreenView.swift
+++ b/ToMyongJi-iOS/Features/SplashScreen/Views/SplashScreenView.swift
@@ -13,7 +13,8 @@ struct SplashScreenView: View {
     
     var body: some View {
         if isActive {
-            IntroView()
+//            IntroView()
+            MainTabView()
         } else {
             VStack {
                 Spacer()


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #10 

### 📝작업 내용

> 아이디 중복 체크, 이메일 인증, 소속 인증 부분 api 연결

### 🔨테스트 결과 > 스크린샷 (선택)

![Simulator Screenshot - iPhone 16 Pro - 2025-02-21 at 20 55 43](https://github.com/user-attachments/assets/f4966766-cfb4-4494-81cd-73177fa85cb2)

![Simulator Screenshot - iPhone 16 Pro - 2025-02-21 at 20 56 00](https://github.com/user-attachments/assets/446e11e6-813e-4d23-a819-c8de850ca231)

![Simulator Screenshot - iPhone 16 Pro - 2025-02-21 at 20 56 26](https://github.com/user-attachments/assets/113c7fa9-89d2-4f64-8331-2c88370f0452)

![Simulator Screenshot - iPhone 16 Pro - 2025-02-21 at 20 56 42](https://github.com/user-attachments/assets/3ea16bcf-d9c1-4a91-87f4-1720f087c3a4)

![Simulator Screenshot - iPhone 16 Pro - 2025-02-21 at 20 56 50](https://github.com/user-attachments/assets/6936785a-d154-4d3e-a3fa-f0843c5c8fc8)

