### PR TITLE
Fix: 회원가입 alert 오류 해결

### DIFF
--- a/ToMyongJi-iOS/Features/SignUp/ViewModels/SignUpViewModel.swift
+++ b/ToMyongJi-iOS/Features/SignUp/ViewModels/SignUpViewModel.swift
@@ -140,7 +140,7 @@ class SignUpViewModel {
                     self?.showAlert(title: "오류", message: error.localizedDescription)
                 }
             } receiveValue: { [weak self] response in
-                if response.statusCode == 0 {
+                if response.statusCode == 200 {
                     self?.showAlert(title: "알림", message: "회원가입이 완료되었습니다.")
                     completion(true)
                 } else {

--- a/ToMyongJi-iOS/Features/SignUp/Views/InputClubAuthenticationView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/InputClubAuthenticationView.swift
@@ -154,13 +154,6 @@ struct InputClubAuthenticationView: View {
             .disabled(!viewModel.isClubVerified)
         }
         .padding()
-        .alert("회원가입 완료", isPresented: $showSignUpAlert) {
-            Button("확인") {
-                dismiss()
-            }
-        } message: {
-            Text("회원가입이 완료되었습니다.\n로그인 화면으로 이동합니다.")
-        }
         .onAppear {
             viewModel.fetchColleges()
         }

--- a/ToMyongJi-iOS/Features/SignUp/Views/InputIDView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/InputIDView.swift
@@ -76,7 +76,7 @@ struct InputIDView: View {
             if !userId.isEmpty {
                 VStack(alignment: .leading, spacing: 5) {
                     if !userId.allSatisfy({ char in (char.isLetter && char.isASCII) || char.isNumber }) {
-                        Text("• 영어와 숫자만 입력해주세요")
+                        Text("영어와 숫자만 입력해주세요")
                             .font(.custom("GmarketSansLight", size: 12))
                             .foregroundStyle(.red)
                     }

--- a/ToMyongJi-iOS/Features/SignUp/Views/InputPasswordView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/InputPasswordView.swift
@@ -55,28 +55,27 @@ struct InputPasswordView: View {
                     isPassword: true,
                     value: $password
                 )
-                .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
                 
                 if !password.isEmpty {
                     VStack(alignment: .leading, spacing: 5) {
                         if !password.contains(where: { $0.isUppercase }) {
-                            Text("* 영문 대문자를 포함해주세요")
+                            Text("영문 대문자를 포함해주세요")
                                 .font(.custom("GmarketSansLight", size: 12))
                                 .foregroundStyle(.red)
                         }
                         if !password.contains(where: { $0.isNumber }) {
-                            Text("* 숫자를 포함해주세요")
+                            Text("숫자를 포함해주세요")
                                 .font(.custom("GmarketSansLight", size: 12))
                                 .foregroundStyle(.red)
                         }
                         if !password.contains(where: { "!@#$%^&*()_+-=[]{}|;:,.<>?".contains($0) }) {
-                            Text("* 특수문자를 포함해주세요")
+                            Text("특수문자를 포함해주세요")
                                 .font(.custom("GmarketSansLight", size: 12))
                                 .foregroundStyle(.red)
                         }
                         if password.count < 8 {
-                            Text("* 8자 이상 입력해주세요")
+                            Text("8자 이상 입력해주세요")
                                 .font(.custom("GmarketSansLight", size: 12))
                                 .foregroundStyle(.red)
                         }

--- a/ToMyongJi-iOS/Features/SignUp/Views/SignUpView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/SignUpView.swift
@@ -14,7 +14,6 @@ enum SignUpPage {
     case clubAuth
 }
 
-// SignUpField 구조체 추가
 struct SignUpField: Identifiable {
     let id = UUID()
     let show: Bool
@@ -109,7 +108,12 @@ struct SignUpView: View {
         }
         .navigationBarHidden(true)
         .alert(viewModel.alertTitle, isPresented: $viewModel.showAlert) {
-            Button("확인", role: .cancel) { }
+            Button("확인", role: .cancel) {
+                if viewModel.alertTitle == "알림" && viewModel.alertMessage == "회원가입이 완료되었습니다." {
+                    dismiss()
+                    showSignup = false
+                }
+            }
         } message: {
             Text(viewModel.alertMessage)
         }


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #10 

### 📝작업 내용

> 회원가입시 회원가입 완료 alert 창이 2번 뜨는 오류 해결

InputClubAuthentication에서 .alert, SignUpView에서의 .alert 2번 호출되는 문제였고 InputClubAutentication의 alert를 삭제 후 viewModel에서 SignUpView로 전달하는 alertTitle, alertMessage를 사용해 1번만 호출하게 했습니다.

### 🔨테스트 결과 > 스크린샷 (선택)

```

// InputClubAuthenticationView.swift
    Button {
        onSignUp()
    } label: {
        Text("회원가입")
            .font(.custom("GmarketSansMedium", size: 15))
            .foregroundStyle(.white)
    }
    .frame(maxWidth: .infinity, alignment: .center)
    .padding(.vertical, 15)
    .background(viewModel.isClubVerified ? Color.softBlue : Color.gray.opacity(0.3))
    .clipShape(RoundedRectangle(cornerRadius: 10))
    .disabled(!viewModel.isClubVerified)
}
.padding()
.onAppear {
    viewModel.fetchColleges()
}
 
```

```
// SignUpView.swift
.alert(viewModel.alertTitle, isPresented: $viewModel.showAlert) {
    Button("확인", role: .cancel) {
        if viewModel.alertTitle == "알림" && viewModel.alertMessage == "회원가입이 완료되었습니다." {
            dismiss()
            showSignup = false
        }
    }
} message: {
    Text(viewModel.alertMessage)
}
```
