### PR TITLE
Fix: 유지보수성을 높이기 위한 endpointEnum 수정

### DIFF
--- a/ToMyongJi-iOS/CoreServices/EndpointEnum.swift
+++ b/ToMyongJi-iOS/CoreServices/EndpointEnum.swift
@@ -21,6 +21,10 @@ protocol Endpoint {
 }
 
 extension Endpoint {
+    var baseURL: String {
+        "15.164.162.164"
+    }
+    
     var url: URL {
         var components = URLComponents()
         components.scheme = "http"

--- a/ToMyongJi-iOS/Features/CollegeAndClubs/Services/CollegesAndClubsEndpoint.swift
+++ b/ToMyongJi-iOS/Features/CollegeAndClubs/Services/CollegesAndClubsEndpoint.swift
@@ -13,11 +13,6 @@ enum CollegesAndClubsEndpoint {
 }
 
 extension CollegesAndClubsEndpoint: Endpoint {
-    var baseURL: String {
-//        return "api.tomyongji.com"
-        return "13.125.66.151"
-    }
-    
     var path: String {
         switch self {
         case .collegesAndClubs:
@@ -29,7 +24,7 @@ extension CollegesAndClubsEndpoint: Endpoint {
         ["Content-Type": "application/json"]
     }
     
-    var parameters: [String : Any] {
+    var parameters: [String: Any] {
         [:]
     }
     

--- a/ToMyongJi-iOS/Features/FindID/Services/FindIDEndpoint.swift
+++ b/ToMyongJi-iOS/Features/FindID/Services/FindIDEndpoint.swift
@@ -13,10 +13,6 @@ enum FindIDEndpoint {
 }
 
 extension FindIDEndpoint: Endpoint {
-    var baseURL: String {
-        return "13.125.66.151"
-    }
-    
     var path: String {
         switch self {
         case .findID:
@@ -37,7 +33,7 @@ extension FindIDEndpoint: Endpoint {
         }
     }
     
-    var query: [String: String] {
+    var query: [String : String] {
         [:]
     }
     

--- a/ToMyongJi-iOS/Features/Login/Services/LoginEndpoint.swift
+++ b/ToMyongJi-iOS/Features/Login/Services/LoginEndpoint.swift
@@ -13,12 +13,6 @@ enum LoginEndpoint {
 }
 
 extension LoginEndpoint: Endpoint {
-    var baseURL: String {
-//        return "api.tomyongji.com"
-        return "13.125.66.151"
-
-    }
-    
     var path: String {
         switch self {
         case .login:

--- a/ToMyongJi-iOS/Features/Main/Views/MainTabView.swift
+++ b/ToMyongJi-iOS/Features/Main/Views/MainTabView.swift
@@ -24,7 +24,12 @@ struct MainTabView: View {
             
             Group {
                 if authManager.isAuthenticated {
-                    CreateReceiptView()
+                    // sample data
+                    let sampleClub = Club(
+                        studentClubId: 1,
+                        studentClubName: "융합소프트웨어학부 학생회"
+                    )
+                    CreateReceiptView(club: sampleClub)
                 } else {
                     Color.clear
                         .onAppear {

--- a/ToMyongJi-iOS/Features/Profile/Services/ProfileEndpoint.swift
+++ b/ToMyongJi-iOS/Features/Profile/Services/ProfileEndpoint.swift
@@ -17,11 +17,6 @@ enum ProfileEndpoint {
 }
 
 extension ProfileEndpoint: Endpoint {
-    var baseURL: String {
-//        return "api.tomyongji.com"
-        return "13.125.66.151"
-    }
-    
     var path: String {
         switch self {
         case .myProfile(let id):

--- a/ToMyongJi-iOS/Features/Receipts/Services/ReceiptEndpoint.swift
+++ b/ToMyongJi-iOS/Features/Receipts/Services/ReceiptEndpoint.swift
@@ -14,11 +14,6 @@ enum ReceiptEndpoint {
 }
 
 extension ReceiptEndpoint: Endpoint {
-    var baseURL: String {
-        //        return "api.tomyongji.com"
-        return "13.125.66.151"
-    }
-    
     var path: String {
         switch self {
         case .receipt(let studentClubId):
@@ -32,7 +27,7 @@ extension ReceiptEndpoint: Endpoint {
         ["Content-Type": "application/json"]
     }
     
-    var parameters: [String : Any] {
+    var parameters: [String: Any] {
         [:]
     }
     

--- a/ToMyongJi-iOS/Features/SignUp/Services/SignUpEndpoint.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Services/SignUpEndpoint.swift
@@ -18,10 +18,6 @@ enum SignUpEndpoint {
 }
 
 extension SignUpEndpoint: Endpoint {
-    var baseURL: String {
-        return "13.125.66.151"
-    }
-    
     var path: String {
         switch self {
         case .getColleges:


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #45 

### 📝작업 내용

> 개발용 서버 endpoint 변경에 따른 수정

- endpoint가 바뀌면 feature에 따른 endpoint를 모두 수정해야했는데, EndpointEnum에 baseURL을 지정해서 유지보수성을 높였습니다.

### 🔨테스트 결과 > 스크린샷 (선택)

```
//
//  EndpointEnum.swift
//  ToMyongJi-iOS
//
//  Created by JunKyu Lee on 12/8/24.
//

import Foundation
import Alamofire

protocol Endpoint {
    var baseURL: String { get }
    var url: URL { get }
    var path: String { get }
    var headers: [String: String] { get }
    var query: [String: String] { get }
    var parameters: [String: Any] { get }
    var method: HTTPMethod { get }
    var encoding: ParameterEncoding { get }
    
}

extension Endpoint {
    var baseURL: String {
        "15.164.162.164"
    }
    
    var url: URL {
        var components = URLComponents()
        components.scheme = "http"
        components.host = self.baseURL
        components.port = 8080
        components.path = self.path
        if !self.query.isEmpty {
            components.queryItems = self.query.map { URLQueryItem(name: $0, value: $1) }
        }
        
        guard let url = components.url else {
            fatalError("Failed to create URL with components: \(components)")
        }
        return url
    }
}

```

