### PR TITLE
Feat: 영수증 작성시 authManager로부터 저장된 사용자 정보 가져오기 구현

### DIFF
--- a/ToMyongJi-iOS/CoreServices/AuthenticationManager.swift
+++ b/ToMyongJi-iOS/CoreServices/AuthenticationManager.swift
@@ -15,6 +15,7 @@ class AuthenticationManager {
     private let accessTokenKey = "accessToken"
     private let userIdKey = "userId"
     private let userRoleKey = "userRole"
+    private let userLoginIdKey = "userLoginId"
     
     // 상태 변화를 감지하기 위한 프로퍼티
     var isAuthenticated: Bool
@@ -29,6 +30,7 @@ class AuthenticationManager {
         UserDefaults.standard.set(accessToken, forKey: accessTokenKey)
         UserDefaults.standard.set(decodedToken.id as Int, forKey: userIdKey)
         UserDefaults.standard.set(decodedToken.auth, forKey: userRoleKey)
+        UserDefaults.standard.set(decodedToken.sub, forKey: userLoginIdKey)
         isAuthenticated = true
     }
     
@@ -37,6 +39,7 @@ class AuthenticationManager {
         UserDefaults.standard.removeObject(forKey: accessTokenKey)
         UserDefaults.standard.removeObject(forKey: userIdKey)
         UserDefaults.standard.removeObject(forKey: userRoleKey)
+        UserDefaults.standard.removeObject(forKey: userLoginIdKey)
         isAuthenticated = false
     }
     
@@ -45,7 +48,7 @@ class AuthenticationManager {
         return UserDefaults.standard.string(forKey: accessTokenKey)
     }
     
-    // 저장된 사용자 ID 가져오기
+    // 저장된 사용자 인덱스 ID 가져오기
     var userId: Int? {
         if let id = UserDefaults.standard.object(forKey: userIdKey) as? Int {
             return id
@@ -56,5 +59,13 @@ class AuthenticationManager {
     // 저장된 사용자 권한 가져오기
     var userRole: String? {
         return UserDefaults.standard.string(forKey: userRoleKey)
+    }
+    
+    // 저장된 사용자 로그인 아이디 가져오기
+    var userLoginId: String? {
+        if let loginId = UserDefaults.standard.object(forKey: userLoginIdKey) as? String {
+            return loginId
+        }
+        return nil
     }
 }

--- a/ToMyongJi-iOS/Features/Receipts/ViewModels/ReceiptViewModel.swift
+++ b/ToMyongJi-iOS/Features/Receipts/ViewModels/ReceiptViewModel.swift
@@ -73,7 +73,7 @@ class ReceiptViewModel {
                 }
             } receiveValue: { [weak self] response in
                 guard let self = self else { return }
-                if response.statusCode == 200 {
+                if response.statusCode == 201 {
                     self.receipts = response.data.receiptList
                     self.balance = response.data.balance
                     self.alertTitle = "성공"

--- a/ToMyongJi-iOS/Features/Receipts/Views/CreateReceiptView.swift
+++ b/ToMyongJi-iOS/Features/Receipts/Views/CreateReceiptView.swift
@@ -12,21 +12,6 @@ struct CreateReceiptView: View {
     @Environment(\.colorScheme) private var scheme
     @Environment(\.dismiss) private var dismiss
     
-    // sample data
-//    @State private var sampleReceipts: [Receipt] = []
-//    @State private var sampleBalance: Int = 1000000
-//    @State private var showCreateForm: Bool = false
-
-//    @State private var date: Date = Date()
-//    @State private var content: String = ""
-//    @State private var deposit: String = ""
-//    @State private var withdrawal: String = ""
-//    
-//    private let sampleClub = Club(
-//        studentClubId: 1,
-//        studentClubName: "융합소프트웨어학부 학생회"
-//    )
-    
     @State private var showCreateForm: Bool = false
     @State private var viewModel = ReceiptViewModel()
     @State private var date: Date = Date()
@@ -122,7 +107,7 @@ struct CreateReceiptView: View {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
         
-        viewModel.userId = AuthenticationManager.shared.userId
+        viewModel.userId = AuthenticationManager.shared.userLoginId ?? ""
         viewModel.date = dateFormatter.string(from: date)
         viewModel.content = content
         viewModel.deposit = Int(deposit) ?? 0


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #24 

### 📝작업 내용

> 영수증 작성시 authManager의 decodedToken으로부터 사용자 로그인 아이디 받아서 viewModel로 넘기는 기능 구현

- AuthenticationManager에서 userLoginId 속성 추가후 디코딩 토큰에서 해당 정보 받아서 저장
- CreateReceiptView에서 영수증 작성 함수 불러올 때 userLoginId 불러서 사용
- viewModel로 넘겨서 서버와 통신

### 🔨테스트 결과 > 스크린샷 (선택)

```
// AuthenticationManager
    // UserDefaults keys
    private let accessTokenKey = "accessToken"
    private let userIdKey = "userId"
    private let userRoleKey = "userRole"
    private let userLoginIdKey = "userLoginId"

// ...

    // 토큰 및 사용자 정보 저장
    func saveAuthentication(accessToken: String, decodedToken: DecodedToken) {
        UserDefaults.standard.set(accessToken, forKey: accessTokenKey)
        UserDefaults.standard.set(decodedToken.id as Int, forKey: userIdKey)
        UserDefaults.standard.set(decodedToken.auth, forKey: userRoleKey)
        UserDefaults.standard.set(decodedToken.sub, forKey: userLoginIdKey)
        isAuthenticated = true
    }

// ...

    // 저장된 사용자 로그인 아이디 가져오기
    var userLoginId: String? {
        if let loginId = UserDefaults.standard.object(forKey: userLoginIdKey) as? String {
            return loginId
        }
        return nil
    }
```

```
// CreateReceiptView

// ...
    private func createReceipt() {
        let dateFormatter = DateFormatter()
        dateFormatter.dateFormat = "yyyy-MM-dd"
        
        viewModel.userId = AuthenticationManager.shared.userLoginId ?? ""
        viewModel.date = dateFormatter.string(from: date)
        viewModel.content = content
        viewModel.deposit = Int(deposit) ?? 0
        viewModel.withdrawal = Int(withdrawal) ?? 0
        
        viewModel.createReceipt()
    }
```

