### PR TITLE
Fix: MainTabView 인증처리 LoginView에서 AuthenticationView로 수정

### DIFF
--- a/ToMyongJi-iOS/Features/Main/Views/MainTabView.swift
+++ b/ToMyongJi-iOS/Features/Main/Views/MainTabView.swift
@@ -71,9 +71,9 @@ struct MainTabView: View {
         } message: {
             Text("로그인 하시겠습니까?")
         }
-        .sheet(isPresented: $showLoginView) {
-            LoginView(showSignup: .constant(false))
-        }
+        .sheet(isPresented: $showLoginView, content: {
+            AuthenticationView()
+        })
     }
 }
 


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #42 

### 📝작업 내용

> MainTabView에서 권한이 없을 경우 LoginView로 이동 -> AuthenticationView로 이동

- LoginView에서 회원가입이 필요할 경우 SignUpView로 이동할 수 없는 문제 발생
- 상위 뷰인 AuthenticationView를 통해 Bool값인 showSignUp을 통해 LoginView, SignUpView 전환 가능하게 수정

### 🔨테스트 결과 > 스크린샷 (선택)

```
//  MainTabView.swift

// ...
        .sheet(isPresented: $showLoginView, content: {
            AuthenticationView()
        })

```

```
// AuthenticationView

struct AuthenticationView: View {
    @State private var showSignup: Bool = false
    @State private var showLogin: Bool = true
    @State private var isKeyboardShowing: Bool = false
    @State private var authManager = AuthenticationManager.shared
    
    var body: some View {
        Group {
            if authManager.isAuthenticated {
                ProfileView()
            } else {
                LoginView(showSignup: $showSignup)
                    .fullScreenCover(isPresented: $showSignup) {
                        SignUpView(showSignup: $showSignup)
                    }
            }
        }

//...
```

