### PR TITLE
Fix: MainTabVie에서 AuthenticationView 불러올때 .fullScreenCover로 수정

### DIFF
--- a/ToMyongJi-iOS/Features/Main/Views/MainTabView.swift
+++ b/ToMyongJi-iOS/Features/Main/Views/MainTabView.swift
@@ -71,7 +71,7 @@ struct MainTabView: View {
         } message: {
             Text("로그인 하시겠습니까?")
         }
-        .sheet(isPresented: $showLoginView, content: {
+        .fullScreenCover(isPresented: $showLoginView, content: {
             AuthenticationView()
         })
     }


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #42 

### 📝작업 내용

> MainTabVie에서 AuthenticationView 불러올때 .fullScreenCover로 수정
- 기존에 .sheet로 되어있던 것을 .fullScreenCover로 변경함에 따라 사용성 증가