### PR TITLE
Feat: 회원가입 정보 동의 추가

### DIFF
--- a/ToMyongJi-iOS/Features/SignUp/ViewModels/SignUpViewModel.swift
+++ b/ToMyongJi-iOS/Features/SignUp/ViewModels/SignUpViewModel.swift
@@ -23,6 +23,7 @@ class SignUpViewModel {
     var selectedRole: String = ""
     
     // UI 상태
+    var isAgree: Bool = false
     var isLoading: Bool = false
     var showAlert: Bool = false
     var alertTitle: String = ""

--- a/ToMyongJi-iOS/Features/SignUp/Views/SignUpAgreeView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/SignUpAgreeView.swift
@@ -1,0 +1,127 @@
+//
+//  SignUpAgreeView.swift
+//  ToMyongJi-iOS
+//
+//  Created by JunKyu Lee on 3/11/25.
+//
+
+import SwiftUI
+
+struct SignUpAgreeView: View {
+    @Binding var isAgree: Bool
+    var onBack: () -> Void
+    var onNext: () -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Button {
+                onBack()
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.title3.bold())
+                    .foregroundStyle(Color.darkNavy)
+                    .contentShape(.rect)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.bottom, 30)
+            Text("약관 동의")
+                .font(.custom("GmarketSansBold", size: 28))
+                .foregroundStyle(Color.darkNavy)
+                .padding(.bottom, 20)
+            Button {
+                isAgree.toggle()
+            } label: {
+                HStack {
+                    if isAgree == false {
+                        Image(systemName: "checkmark.square")
+                            .font(.title2)
+                            .foregroundStyle(Color.gray.opacity(0.5))
+                    } else {
+                        Image(systemName: "checkmark.square.fill")
+                            .font(.title2)
+                            .foregroundStyle(Color.darkNavy)
+                    }
+                    Text("전체 동의하기")
+                        .font(.custom("GmarketSansBold", size: 18))
+                        .foregroundStyle(isAgree ? Color.darkNavy : Color.gray.opacity(0.5))
+                }
+            }
+            Button {
+                print(isAgree)
+                isAgree.toggle()
+            } label: {
+                HStack {
+                    if isAgree == false {
+                        Image(systemName: "checkmark.square")
+                            .font(.title2)
+                            .foregroundStyle(Color.gray.opacity(0.5))
+                    } else {
+                        Image(systemName: "checkmark.square.fill")
+                            .font(.title2)
+                            .foregroundStyle(Color.darkNavy)
+                    }
+                    Text("명지대학교 학생입니다.")
+                        .font(.custom("GmarketSansMedium", size: 18))
+                        .foregroundStyle(isAgree ? Color.darkNavy : Color.gray.opacity(0.5))
+                }
+            }
+            Button {
+                print(isAgree)
+                isAgree.toggle()
+            } label: {
+                HStack {
+                    if isAgree == false {
+                        Image(systemName: "checkmark.square")
+                            .font(.title2)
+                            .foregroundStyle(Color.gray.opacity(0.5))
+
+                    } else {
+                        Image(systemName: "checkmark.square.fill")
+                            .font(.title2)
+                            .foregroundStyle(Color.darkNavy)
+                    }
+                    Text("서비스 이용약관 동의")
+                        .font(.custom("GmarketSansMedium", size: 18))
+                        .foregroundStyle(isAgree ? Color.darkNavy : Color.gray.opacity(0.5))
+                }
+            }
+            Button {
+                print(isAgree)
+                isAgree.toggle()
+            } label: {
+                HStack {
+                    if isAgree == false {
+                        Image(systemName: "checkmark.square")
+                            .font(.title2)
+                            .foregroundStyle(Color.gray.opacity(0.5))
+                    } else {
+                        Image(systemName: "checkmark.square.fill")
+                            .font(.title2)
+                            .foregroundStyle(Color.darkNavy)
+                    }
+                    Text("개인정보 수집 및 이용 동의")
+                        .font(.custom("GmarketSansMedium", size: 18))
+                        .foregroundStyle(isAgree ? Color.darkNavy : Color.gray.opacity(0.5))
+                }
+            }
+            Spacer()
+            Button {
+                onNext()
+            } label: {
+                Text("다음")
+                    .font(.custom("GmarketSansMedium", size: 15))
+                    .foregroundStyle(.white)
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 15)
+            .background((!isAgree) ? Color.gray.opacity(0.3) : Color.softBlue)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .disabled(!isAgree)
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    SignUpAgreeView(isAgree: .constant(false), onBack: {}, onNext: {})
+}

--- a/ToMyongJi-iOS/Features/SignUp/Views/SignUpView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/SignUpView.swift
@@ -34,7 +34,7 @@ struct SignUpView: View {
         NavigationStack {
             switch currentPage {
             case .agree:
-                SignUpAgreeView(onBack: {dismiss()},
+                SignUpAgreeView(isAgree: $viewModel.isAgree, onBack: {dismiss()},
                                 onNext: {
                     if viewModel.isAgree {
                         withAnimation {

--- a/ToMyongJi-iOS/Features/SignUp/Views/SignUpView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/SignUpView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 enum SignUpPage {
+    case agree
     case id
     case password
     case email
@@ -32,6 +33,15 @@ struct SignUpView: View {
     var body: some View {
         NavigationStack {
             switch currentPage {
+            case .agree:
+                SignUpAgreeView(onBack: {dismiss()},
+                                onNext: {
+                    if viewModel.isAgree {
+                        withAnimation {
+                            currentPage = .id
+                        }
+                    }
+                })
             case .id:
                 InputIDView(
                     userId: $viewModel.userId,


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #10 

### 📝작업 내용

> 회원가입 정보 동의
- SignUpViewModel의 멤버 변수에 isAgree 추가
- 회원가입 정보 동의 SignUpAgreeView 추가

### 🔨테스트 결과 > 스크린샷 (선택)

<img width="247" alt="image" src="https://github.com/user-attachments/assets/6a787a43-cdc3-4081-925e-31d326c47baf" />


