### PR TITLE
Feat: 사용자 권한에 따른 TabView 분기 처리 구현

### DIFF
--- a/ToMyongJi-iOS.xcodeproj/project.pbxproj
+++ b/ToMyongJi-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F58E93F12D81A7F4009C1F74 /* AdminTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58E93F02D81A7F4009C1F74 /* AdminTabView.swift */; };
 		F59C39F52CFB1F8E002AD9DA /* ToMyongJi_iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59C39F32CFB1F8E002AD9DA /* ToMyongJi_iOSApp.swift */; };
 		F59C39F62CFB1F8E002AD9DA /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59C39EA2CFB1F8E002AD9DA /* ContentView.swift */; };
 		F59C39F72CFB1F8E002AD9DA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F59C39F02CFB1F8E002AD9DA /* Assets.xcassets */; };
@@ -19,6 +20,7 @@
 
 /* Begin PBXFileReference section */
 		F50703992CFABC0D00D0817A /* ToMyongJi-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ToMyongJi-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F58E93F02D81A7F4009C1F74 /* AdminTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminTabView.swift; sourceTree = "<group>"; };
 		F59C39EA2CFB1F8E002AD9DA /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		F59C39EE2CFB1F8E002AD9DA /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		F59C39F02CFB1F8E002AD9DA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 			isa = PBXGroup;
 			children = (
 				F59C39FD2CFB21D5002AD9DA /* MainTabView.swift */,
+				F58E93F02D81A7F4009C1F74 /* AdminTabView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -289,6 +292,7 @@
 				F59C39F52CFB1F8E002AD9DA /* ToMyongJi_iOSApp.swift in Sources */,
 				F59C39F62CFB1F8E002AD9DA /* ContentView.swift in Sources */,
 				F59C39FE2CFB21D5002AD9DA /* MainTabView.swift in Sources */,
+				F58E93F12D81A7F4009C1F74 /* AdminTabView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ToMyongJi-iOS/CoreServices/AuthenticationManager.swift
+++ b/ToMyongJi-iOS/CoreServices/AuthenticationManager.swift
@@ -18,11 +18,16 @@ class AuthenticationManager {
     private let userLoginIdKey = "userLoginId"
     
     // 상태 변화를 감지하기 위한 프로퍼티
-    var isAuthenticated: Bool
+    var isAuthenticated: Bool = false
+    var userRole: String? = nil
+    var userId: Int? = nil
+    var userLoginId: String? = nil
     
     private init() {
         // 초기화 시 현재 인증 상태 설정
         self.isAuthenticated = UserDefaults.standard.string(forKey: accessTokenKey) != nil
+        self.userRole = UserDefaults.standard.string(forKey: userRoleKey)
+        self.userLoginId = UserDefaults.standard.string(forKey: userLoginIdKey)
     }
     
     // 토큰 및 사용자 정보 저장
@@ -31,7 +36,11 @@ class AuthenticationManager {
         UserDefaults.standard.set(decodedToken.id as Int, forKey: userIdKey)
         UserDefaults.standard.set(decodedToken.auth, forKey: userRoleKey)
         UserDefaults.standard.set(decodedToken.sub, forKey: userLoginIdKey)
+        
         isAuthenticated = true
+        userRole = decodedToken.auth
+        userId = decodedToken.id
+        userLoginId = decodedToken.sub
     }
     
     // 로그아웃 시 저장된 정보 삭제
@@ -40,32 +49,14 @@ class AuthenticationManager {
         UserDefaults.standard.removeObject(forKey: userIdKey)
         UserDefaults.standard.removeObject(forKey: userRoleKey)
         UserDefaults.standard.removeObject(forKey: userLoginIdKey)
+        
         isAuthenticated = false
+        userRole = nil
+        userId = nil
+        userLoginId = nil
     }
     
-    // 저장된 토큰 가져오기
     var accessToken: String? {
         return UserDefaults.standard.string(forKey: accessTokenKey)
-    }
-    
-    // 저장된 사용자 인덱스 ID 가져오기
-    var userId: Int? {
-        if let id = UserDefaults.standard.object(forKey: userIdKey) as? Int {
-            return id
-        }
-        return nil
-    }
-    
-    // 저장된 사용자 권한 가져오기
-    var userRole: String? {
-        return UserDefaults.standard.string(forKey: userRoleKey)
-    }
-    
-    // 저장된 사용자 로그인 아이디 가져오기
-    var userLoginId: String? {
-        if let loginId = UserDefaults.standard.object(forKey: userLoginIdKey) as? String {
-            return loginId
-        }
-        return nil
     }
 }

--- a/ToMyongJi-iOS/CoreServices/EndpointEnum.swift
+++ b/ToMyongJi-iOS/CoreServices/EndpointEnum.swift
@@ -22,14 +22,15 @@ protocol Endpoint {
 
 extension Endpoint {
     var baseURL: String {
-        "15.164.162.164"
+//        "15.164.162.164"
+        "api.tomyongji.com"
     }
     
     var url: URL {
         var components = URLComponents()
-        components.scheme = "http"
+        components.scheme = "https"
         components.host = self.baseURL
-        components.port = 8080
+//        components.port = 8080
         components.path = self.path
         if !self.query.isEmpty {
             components.queryItems = self.query.map { URLQueryItem(name: $0, value: $1) }

--- a/ToMyongJi-iOS/Features/Admin/Views/AdminView.swift
+++ b/ToMyongJi-iOS/Features/Admin/Views/AdminView.swift
@@ -8,7 +8,9 @@
 import SwiftUI
 
 struct AdminView: View {
+    @Bindable private var authManager = AuthenticationManager.shared
     @State private var viewModel = AdminViewModel()
+    @State private var showLogoutAlert: Bool = false
     @FocusState private var isFocused: Bool
     
     var body: some View {
@@ -132,8 +134,38 @@ struct AdminView: View {
                     )
                 }
                 .padding(.top, 30)
+                
+                // 로그아웃 버튼
+                Button(action: {
+                    showLogoutAlert = true
+                }) {
+                    HStack {
+                        Text("로그아웃")
+                            .font(.custom("GmarketSansMedium", size: 14))
+                            .foregroundColor(.white)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 15)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color.withdrawal)
+                    )
+                }
+                .padding(.horizontal, 10)
+                .padding(.top, 20)
+                .padding(.bottom, 10)
             }
             .padding(20)
+        }
+        .alert("로그아웃", isPresented: $showLogoutAlert) {
+            Button("취소", role: .cancel) { }
+            Button("로그아웃", role: .destructive) {
+                withAnimation {
+                    authManager.clearAuthentication()
+                }
+            }
+        } message: {
+            Text("정말 로그아웃 하시겠습니까?")
         }
         .alert(viewModel.alertTitle, isPresented: $viewModel.showAlert) {
             Button("확인", role: .cancel) { }

--- a/ToMyongJi-iOS/Features/Main/Views/AdminTabView.swift
+++ b/ToMyongJi-iOS/Features/Main/Views/AdminTabView.swift
@@ -1,0 +1,34 @@
+//
+//  AdminTabView.swift
+//  ToMyongJi-iOS
+//
+//  Created by JunKyu Lee on 3/12/25.
+//
+
+import SwiftUI
+
+struct AdminTabView: View {
+    @State private var selectedTab = 1
+    
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            CollegesAndClubsView()
+                .tabItem {
+                    Image(systemName: "magnifyingglass")
+                    Text("조회")
+                }
+                .tag(1)
+            AdminView()
+                .tabItem {
+                    Image(systemName: "gearshape")
+                    Text("관리")
+                }
+                .tag(2)
+        }
+        .tint(Color.softBlue)
+    }
+}
+
+#Preview {
+    AdminTabView()
+}

--- a/ToMyongJi-iOS/Features/Main/Views/MainTabView.swift
+++ b/ToMyongJi-iOS/Features/Main/Views/MainTabView.swift
@@ -16,77 +16,81 @@ struct MainTabView: View {
     @State private var profileViewModel = ProfileViewModel()
     
     var body: some View {
-        TabView(selection: $selectedTab) {
-            CollegesAndClubsView()
-                .tabItem {
-                    Image(systemName: "magnifyingglass")
-                    Text("조회")
-                }
-                .tag(1)
-            
-            Group {
-                if authManager.isAuthenticated {
-                    if profileViewModel.studentClubId != 0 {
-                        CreateReceiptView(club: Club(
-                            studentClubId: profileViewModel.studentClubId,
-                            studentClubName: profileViewModel.studentClub
-                        ))
+        if authManager.userRole == "ADMIN" {
+            AdminTabView()
+        } else {
+            TabView(selection: $selectedTab) {
+                CollegesAndClubsView()
+                    .tabItem {
+                        Image(systemName: "magnifyingglass")
+                        Text("조회")
+                    }
+                    .tag(1)
+                
+                Group {
+                    if authManager.isAuthenticated {
+                        if profileViewModel.studentClubId != 0 {
+                            CreateReceiptView(club: Club(
+                                studentClubId: profileViewModel.studentClubId,
+                                studentClubName: profileViewModel.studentClub
+                            ))
+                        } else {
+                            ProgressView()
+                                .onAppear {
+                                    profileViewModel.fetchUserProfile()
+                                }
+                        }
                     } else {
-                        ProgressView()
+                        Color.clear
                             .onAppear {
-                                profileViewModel.fetchUserProfile()
+                                previousTab = selectedTab
+                                showLoginAlert = true
                             }
                     }
-                } else {
-                    Color.clear
-                        .onAppear {
-                            previousTab = selectedTab
-                            showLoginAlert = true
-                        }
                 }
-            }
-            .tabItem {
-                Image(systemName: "pencil")
-                Text("작성")
-            }
-            .tag(2)
-            
-            Group {
-                if authManager.isAuthenticated {
-                    ProfileView()
-                } else {
-                    Color.clear
-                        .onAppear {
-                            previousTab = selectedTab
-                            showLoginAlert = true
-                        }
+                .tabItem {
+                    Image(systemName: "pencil")
+                    Text("작성")
                 }
+                .tag(2)
+                
+                Group {
+                    if authManager.isAuthenticated {
+                        ProfileView()
+                    } else {
+                        Color.clear
+                            .onAppear {
+                                previousTab = selectedTab
+                                showLoginAlert = true
+                            }
+                    }
+                }
+                .tabItem {
+                    Image(systemName: "person.circle")
+                    Text("프로필")
+                }
+                .tag(3)
             }
-            .tabItem {
-                Image(systemName: "person.circle")
-                Text("프로필")
+            .tint(Color.softBlue)
+            .navigationBarBackButtonHidden()
+            .alert("로그인 후 이용 가능합니다.", isPresented: $showLoginAlert) {
+                Button("취소", role: .cancel) {
+                    selectedTab = 1
+                }
+                Button("확인") {
+                    showLoginView = true
+                }
+            } message: {
+                Text("로그인 하시겠습니까?")
             }
-            .tag(3)
-        }
-        .tint(Color.softBlue)
-        .navigationBarBackButtonHidden()
-        .alert("로그인 후 이용 가능합니다.", isPresented: $showLoginAlert) {
-            Button("취소", role: .cancel) {
-                selectedTab = 1
-            }
-            Button("확인") {
-                showLoginView = true
-            }
-        } message: {
-            Text("로그인 하시겠습니까?")
-        }
-        .fullScreenCover(isPresented: $showLoginView, content: {
-            AuthenticationView()
-        })
-        .onChange(of: authManager.isAuthenticated) { _, newValue in
-            if newValue {
-                selectedTab = previousTab
-                profileViewModel.fetchUserProfile()
+            .fullScreenCover(isPresented: $showLoginView, content: {
+                AuthenticationView()
+            })
+            .onChange(of: authManager.isAuthenticated) { _, newValue in
+                if newValue {
+                    selectedTab = previousTab
+                    profileViewModel.fetchUserProfile()
+                }
             }
         }
     }

--- a/ToMyongJi-iOS/Features/SplashScreen/Views/SplashScreenView.swift
+++ b/ToMyongJi-iOS/Features/SplashScreen/Views/SplashScreenView.swift
@@ -14,7 +14,7 @@ struct SplashScreenView: View {
     var body: some View {
         if isActive {
 //            IntroView()
-            MainTabView()
+            ContentView()
         } else {
             VStack {
                 Spacer()


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #26 

### 📝작업 내용

> 사용자 권한에 따른 TabView 분기 처리 구현
- AuthenticationManager에서 인증상태 관리를 통해 분기 처리
- SplashView -> ContentView -> MainTabView로 이동
- MainTabView에서 authManager.userRole에 따른 분기 처리

### 🔨테스트 결과 > 스크린샷 (선택)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-13 at 09 53 03](https://github.com/user-attachments/assets/16975614-04ab-4330-9bcc-41652c25d053)

![Simulator Screenshot - iPhone 16 Pro - 2025-03-13 at 09 59 01](https://github.com/user-attachments/assets/4ecd6bba-1d59-44ad-b7c0-b02b6ae54720)

![Simulator Screenshot - iPhone 16 Pro - 2025-03-13 at 09 53 10](https://github.com/user-attachments/assets/daf08423-cfe9-4fae-a2f9-1d172394a0c3)




