### PR TITLE
Feat: 회장 조회, 생성, 변경을 위한 단과대학 및 소속 정보 조회

### DIFF
--- a/ToMyongJi-iOS/Features/Admin/Models/Member.swift
+++ b/ToMyongJi-iOS/Features/Admin/Models/Member.swift
@@ -1,0 +1,26 @@
+//
+//  Member.swift
+//  ToMyongJi-iOS
+//
+//  Created by JunKyu Lee on 3/13/25.
+//
+
+import Foundation
+
+struct Member: Codable {
+    let memberID: Int
+    let studentNum: String
+    let name: String
+}
+
+struct AddMemberRequest: Codable {
+    let clubID: Int
+    let studentNum: String
+    let name: String
+}
+
+struct AddMemberResponse: Codable {
+    let statusCode: Int
+    let statusMessage: String
+    let data: Member?
+}

--- a/ToMyongJi-iOS/Features/Admin/Models/President.swift
+++ b/ToMyongJi-iOS/Features/Admin/Models/President.swift
@@ -1,0 +1,39 @@
+//
+//  President.swift
+//  ToMyongJi-iOS
+//
+//  Created by JunKyu Lee on 3/13/25.
+//
+
+import Foundation
+
+struct President: Codable {
+    let clubID: Int
+    let studentNum: String
+    let name: String
+}
+
+struct AddPresidentRequest: Codable {
+    let clubID: Int
+    let studentNum: String
+    let name: String
+}
+
+struct AddPresidentResponse: Codable {
+    let statusCode: Int
+    let statusMessage: String
+    let data: President?
+}
+
+struct UpdatePresidentRequest: Codable {
+    let clubID: Int
+    let studentNum: String
+    let name: String
+}
+
+struct UpdatePresidentResponse: Codable {
+    let statusCode: Int
+    let statusMessage: String
+    let data: President?
+}
+

--- a/ToMyongJi-iOS/Features/Admin/Services/AdminEndpoint.swift
+++ b/ToMyongJi-iOS/Features/Admin/Services/AdminEndpoint.swift
@@ -1,0 +1,92 @@
+//
+//  AdminEndpoint.swift
+//  ToMyongJi-iOS
+//
+//  Created by JunKyu Lee on 3/13/25.
+//
+
+import Foundation
+import Alamofire
+
+enum AdminEndpoint {
+    case getCollegesAndClubs
+    case getPresident(clubId: Int)
+    case addPresident(clubID: Int, studentNum: String, name: String)
+    case updatePresident(clubID: Int, studentNum: String, name: String)
+    case getMember(clubId: Int)
+    case addMember(clubID: Int, studentNum: String, name: String)
+    case deleteMember(memberId: Int)
+}
+
+extension AdminEndpoint: Endpoint {
+    var path: String {
+        switch self {
+        case .getCollegesAndClubs:
+            return "/api/collegesAndClubs"
+        case .getPresident(let clubId):
+            return "/api/admin/president/\(clubId)"
+        case .addPresident:
+            return "/api/admin/president"
+        case .updatePresident:
+            return "/api/admin/president"
+        case .getMember(let clubId):
+            return "/api/admin/member/\(clubId)"
+        case .addMember:
+            return "/api/admin/member"
+        case .deleteMember(let memberId):
+            return "/api/admin/member/\(memberId)"
+        }
+    }
+    
+    var headers: [String : String] {
+        guard let token = AuthenticationManager.shared.accessToken else {
+            return ["Content-Type": "application/json"]
+        }
+        return [
+            "Content-Type": "application/json",
+            "Authorization": "Bearer \(token)"
+        ]
+    }
+    
+    var parameters: [String: Any] {
+        switch self {
+        case .addPresident(let clubID, let studentNum, let name):
+            let request = AddPresidentRequest(clubID: clubID, studentNum: studentNum, name: name)
+            return try! JSONSerialization.jsonObject(with: JSONEncoder().encode(request)) as! [String: Any]
+        case .updatePresident(let clubID, let studentNum, let name):
+            let request = UpdatePresidentRequest(clubID: clubID, studentNum: studentNum, name: name)
+            return try! JSONSerialization.jsonObject(with: JSONEncoder().encode(request)) as! [String: Any]
+        case .addMember(let clubID, let studentNum, let name):
+            let request = AddMemberRequest(clubID: clubID, studentNum: studentNum, name: name)
+            return try! JSONSerialization.jsonObject(with: JSONEncoder().encode(request)) as! [String: Any]
+        default:
+            return [:]
+        }
+    }
+    
+    var query: [String : String] {
+        [:]
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .addPresident, .addMember:
+            return .post
+        case .updatePresident:
+            return .patch
+        case .deleteMember:
+            return .delete
+        default:
+            return .get
+        }
+    }
+    
+    var encoding: ParameterEncoding {
+        switch method {
+        case .get, .delete:
+            return URLEncoding.default
+        default:
+            return JSONEncoding.default
+        }
+    }
+}

--- a/ToMyongJi-iOS/Features/Admin/Views/AdminView.swift
+++ b/ToMyongJi-iOS/Features/Admin/Views/AdminView.swift
@@ -16,14 +16,12 @@ struct AdminView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                // admin 타이틀
                 VStack(alignment: .leading, spacing: 30) {
                     Text("관리자 페이지")
                         .font(.custom("GmarketSansBold", size: 28))
                         .foregroundStyle(Color.darkNavy)
                         .padding(.bottom, 20)
                     
-                    // 회장 관리
                     VStack(alignment: .leading, spacing: 15) {
                         Text("회장 관리")
                             .font(.custom("GmarketSansMedium", size: 20))
@@ -32,6 +30,9 @@ struct AdminView: View {
                             .font(.custom("GmarketSansLight", size: 13))
                             .foregroundStyle(.gray)
                             .padding(.top, -5)
+                        
+                        // 회장 저장/변경을 위한 단과 대학 및 학생회 선택
+                        SelectCollegesAndClubsView(viewModel: viewModel)
                     }
                     
                     /// 현재 회장 정보

--- a/ToMyongJi-iOS/Features/Admin/Views/SelectCollegesAndClubsView.swift
+++ b/ToMyongJi-iOS/Features/Admin/Views/SelectCollegesAndClubsView.swift
@@ -1,0 +1,63 @@
+//
+//  SelectCollegesAndClubsView.swift
+//  ToMyongJi-iOS
+//
+//  Created by JunKyu Lee on 3/13/25.
+//
+
+import SwiftUI
+
+struct SelectCollegesAndClubsView: View {
+    var viewModel: AdminViewModel
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            // 단과대학 선택
+            Menu {
+                ForEach(viewModel.colleges) { college in
+                    Button(college.collegeName) {
+                        viewModel.selectedCollege = college
+                        viewModel.selectedClub = nil
+                    }
+                }
+            } label: {
+                HStack {
+                    Text(viewModel.selectedCollege?.collegeName ?? "단과대학 선택")
+                        .font(.custom("GmarketSansLight", size: 15))
+                    Spacer()
+                    Image(systemName: "chevron.down")
+                }
+                .foregroundStyle(Color.darkNavy)
+                .padding()
+                .background(Color.gray.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+            }
+            
+            // 소속 선택
+            if let college = viewModel.selectedCollege {
+                Menu {
+                    ForEach(college.clubs) { club in
+                        Button(club.studentClubName) {
+                            viewModel.selectedClub = club
+                        }
+                    }
+                } label: {
+                    HStack {
+                        Text(viewModel.selectedClub?.studentClubName ?? "소속 선택")
+                            .font(.custom("GmarketSansLight", size: 15))
+                        Spacer()
+                        Image(systemName: "chevron.down")
+                    }
+                    .foregroundStyle(Color.darkNavy)
+                    .padding()
+                    .background(Color.gray.opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+            }
+        }
+        .onAppear {
+            viewModel.fetchCollegesAndClubs()
+        }
+    }
+    
+}

--- a/ToMyongJi-iOS/Features/Profile/Models/ClubMember.swift
+++ b/ToMyongJi-iOS/Features/Profile/Models/ClubMember.swift
@@ -38,7 +38,7 @@ struct GetClubMembersResponse: Codable {
     let data: [ClubMemberData]
 }
 
-struct DeleteMemberResponse: Codable {
+struct DeleteClubMemberResponse: Codable {
     let statusCode: Int
     let statusMessage: String
     let data: ClubMemberData

--- a/ToMyongJi-iOS/Features/Profile/ViewModels/ProfileViewModel.swift
+++ b/ToMyongJi-iOS/Features/Profile/ViewModels/ProfileViewModel.swift
@@ -143,7 +143,7 @@ class ProfileViewModel {
     func deleteMember(studentNum: String) {
         networkingManager.run(
             ProfileEndpoint.deleteMember(studentNum: studentNum),
-            type: DeleteMemberResponse.self
+            type: DeleteClubMemberResponse.self
         )
         .sink { completion in
             if case .failure(let error) = completion {


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #26 

### 📝작업 내용

> 회장 조회, 생성, 변경을 위한 단과대학 및 소속 정보 조회
- 단과대학 및 소속 정보 조회를 할 수 있는 SelectCollegesAndClubsView 구현
- AdminViewModel의 fetchCollegesAndClubs() 구현
- 받은 정보를 바탕으로 해당 소속의 회장, 소속원 CRD 구현 예정

### 🔨테스트 결과 > 스크린샷 (선택)

![Simulator Screenshot - iPhone 16 Pro - 2025-03-13 at 14 38 55](https://github.com/user-attachments/assets/284fd4bf-a0df-4afa-a3ea-1b327287ca33)


