### PR TITLE
Feat: 토큰 만료 처리 및 Admin 회장 관리 기능

### DIFF
--- a/ToMyongJi-iOS/Features/Admin/Views/AdminView.swift
+++ b/ToMyongJi-iOS/Features/Admin/Views/AdminView.swift
@@ -79,9 +79,31 @@ struct AdminView: View {
                                 )
                             
                             Button {
-                                viewModel.updatePresident()
+                                if viewModel.newPresidentStudentNum.isEmpty || viewModel.newPresidentName.isEmpty {
+                                    viewModel.alertTitle = "입력 오류"
+                                    viewModel.alertMessage = "학번과 이름을 모두 입력해주세요."
+                                    viewModel.showAlert = true
+                                    return
+                                } else if viewModel.newPresidentStudentNum == viewModel.currentPresidentStudentNum {
+                                    viewModel.alertTitle = "입력 오류"
+                                    viewModel.alertMessage = "현재 회장과 동일한 학번입니다."
+                                    viewModel.showAlert = true
+                                    return
+                                } else if viewModel.newPresidentName == viewModel.currentPresidentName {
+                                    viewModel.alertTitle = "입력 오류"
+                                    viewModel.alertMessage = "현재 회장과 동일한 이름입니다."
+                                    viewModel.showAlert = true
+                                    return
+                                } else {
+                                    // 현재 회장 정보가 비어있으면 추가, 있으면 변경
+                                    if viewModel.currentPresidentStudentNum.isEmpty && viewModel.currentPresidentName.isEmpty {
+                                        viewModel.addPresident()
+                                    } else {
+                                        viewModel.updatePresident()
+                                    }
+                                }
                             } label: {
-                                Text("변경")
+                                Text("저장")
                                     .font(.custom("GmarketSansMedium", size: 14))
                                     .foregroundColor(.white)
                                     .padding(.horizontal, 15)
@@ -109,30 +131,30 @@ struct AdminView: View {
                             .padding(.top, -5)
                     }
                     
-                    /// 구성원 추가
-                    AddAdminMemberRow(
-                        studentNum: $viewModel.newMemberStudentNum,
-                        name: $viewModel.newMemberName
-                    ) {
-                        viewModel.addMember()
-                    }
-                    .padding(.bottom, 20)
-                    
-                    /// 구성원 목록
-                    VStack {
-                        ForEach(viewModel.members) { member in
-                            AdminMemberRow(
-                                studentNum: member.studentNum,
-                                name: member.name
-                            ) {
-                                viewModel.deleteMember(studentNum: member.studentNum)
-                            }
-                        }
-                    }
-                    .background(
-                        RoundedRectangle(cornerRadius: 15)
-                            .fill(Color.softBlue.opacity(0.3))
-                    )
+//                    /// 구성원 추가
+//                    AddAdminMemberRow(
+//                        studentNum: $viewModel.newMemberStudentNum,
+//                        name: $viewModel.newMemberName
+//                    ) {
+//                        viewModel.addMember()
+//                    }
+//                    .padding(.bottom, 20)
+//                    
+//                    /// 구성원 목록
+//                    VStack {
+//                        ForEach(viewModel.members) { member in
+//                            AdminMemberRow(
+//                                studentNum: member.studentNum,
+//                                name: member.name
+//                            ) {
+//                                viewModel.deleteMember(studentNum: member.studentNum)
+//                            }
+//                        }
+//                    }
+//                    .background(
+//                        RoundedRectangle(cornerRadius: 15)
+//                            .fill(Color.softBlue.opacity(0.3))
+//                    )
                 }
                 .padding(.top, 30)
                 

--- a/ToMyongJi-iOS/Features/Main/Views/AdminTabView.swift
+++ b/ToMyongJi-iOS/Features/Main/Views/AdminTabView.swift
@@ -9,24 +9,44 @@ import SwiftUI
 
 struct AdminTabView: View {
     @State private var selectedTab = 1
+    @State private var showLoginView = false
+    @State private var showTokenExpiredAlert = false
+    @Bindable private var authManager = AuthenticationManager.shared
     
     var body: some View {
-        TabView(selection: $selectedTab) {
-            CollegesAndClubsView()
-                .tabItem {
-                    Image(systemName: "magnifyingglass")
-                    Text("조회")
+            TabView(selection: $selectedTab) {
+                CollegesAndClubsView()
+                    .tabItem {
+                        Image(systemName: "magnifyingglass")
+                        Text("조회")
+                    }
+                    .tag(1)
+                AdminView()
+                    .tabItem {
+                        Image(systemName: "gearshape")
+                        Text("관리")
+                    }
+                    .tag(2)
+            }
+            .tint(Color.softBlue)
+            // 토큰 만료 알림 추가
+            .alert("세션 만료", isPresented: $showTokenExpiredAlert) {
+                Button("확인") {
+                    authManager.clearAuthentication()
+                    showLoginView = true
                 }
-                .tag(1)
-            AdminView()
-                .tabItem {
-                    Image(systemName: "gearshape")
-                    Text("관리")
-                }
-                .tag(2)
+            } message: {
+                Text("접속한지 오랜시간이 지났습니다. 다시 로그인해주세요.")
+            }
+            .fullScreenCover(isPresented: $showLoginView, content: {
+                AuthenticationView()
+            })
+            // 토큰 만료 감지 추가
+            .onReceive(NotificationCenter.default.publisher(for: .tokenExpired)) { _ in
+                selectedTab = 1
+                showTokenExpiredAlert = true
+            }
         }
-        .tint(Color.softBlue)
-    }
 }
 
 #Preview {

--- a/ToMyongJi-iOS/Features/Main/Views/MainTabView.swift
+++ b/ToMyongJi-iOS/Features/Main/Views/MainTabView.swift
@@ -14,6 +14,7 @@ struct MainTabView: View {
     @State private var showLoginView: Bool = false
     @State private var previousTab: Int = 1
     @State private var profileViewModel = ProfileViewModel()
+    @State private var showTokenExpiredAlert: Bool = false // 추가
     
     var body: some View {
         if authManager.userRole == "ADMIN" {
@@ -83,6 +84,15 @@ struct MainTabView: View {
             } message: {
                 Text("로그인 하시겠습니까?")
             }
+            // 토큰 만료 알림 추가
+            .alert("세션 만료", isPresented: $showTokenExpiredAlert) {
+                Button("확인") {
+                    authManager.clearAuthentication()
+                    showLoginView = true
+                }
+            } message: {
+                Text("접속한지 오랜시간이 지났습니다. 다시 로그인해주세요.")
+            }
             .fullScreenCover(isPresented: $showLoginView, content: {
                 AuthenticationView()
             })
@@ -91,6 +101,12 @@ struct MainTabView: View {
                     selectedTab = previousTab
                     profileViewModel.fetchUserProfile()
                 }
+            }
+            // 토큰 만료 감지 추가
+            .onReceive(NotificationCenter.default.publisher(for: .tokenExpired)) { _ in
+                selectedTab = 1
+                previousTab = 1
+                showTokenExpiredAlert = true
             }
         }
     }


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #26 #42 

### 📝작업 내용

> 토큰 만료 처리 및 자동 로그아웃 기능 
- AuthenticationManager에서 decodedToken의 exp 데이터를 사용해서 토큰 만료 처리 구현
- 토큰이 만료되면 UserDefaults에 저장한 로그인 사용자 데이터 모두 초기화 및 자동 로그아웃 기능 구현
- 각 View의 상위 View에서 토큰 만료 처리 및 자동 로그아웃 기능 구현

> Admin 회장 관리 기능
- AdminEndpoint의 getPresident, addPresident, updatePresident로 나눠서 almofire 세팅
- AdminViewModel의 fetchPresident, addPresident, updatePresident를 combine을 사용해서 구현

### 🔨테스트 결과 > 스크린샷 (선택)

![Simulator Screenshot - iPhone 16 Pro - 2025-03-15 at 12 05 05](https://github.com/user-attachments/assets/15bce93e-8690-4c39-8a16-0ff7b0febd70)

![Simulator Screenshot - iPhone 16 Pro - 2025-03-15 at 12 05 18](https://github.com/user-attachments/assets/9a6d8bde-2d43-4198-8b01-d1e7130d0eca)

![Simulator Screenshot - iPhone 16 Pro - 2025-03-15 at 12 05 23](https://github.com/user-attachments/assets/dc973119-8a72-444c-b40b-eb716a2aad1d)
