### PR TITLE
Design: Login, SignUp, FindID 레이아웃 및 tint 색상 수정

### DIFF
--- a/ToMyongJi-iOS/Features/Admin/Views/Member/AddAdminMemberRow.swift
+++ b/ToMyongJi-iOS/Features/Admin/Views/Member/AddAdminMemberRow.swift
@@ -36,7 +36,7 @@ struct AddAdminMemberRow: View {
                     .foregroundColor(.white)
                     .padding(.horizontal, 15)
                     .padding(.vertical, 8)
-                    .background(Color.deposit)
+                    .background(Color.darkNavy)
                     .cornerRadius(8)
             }
         }

--- a/ToMyongJi-iOS/Features/Admin/Views/Member/AdminMemberView.swift
+++ b/ToMyongJi-iOS/Features/Admin/Views/Member/AdminMemberView.swift
@@ -25,7 +25,7 @@ struct AdminMemberView: View {
                     .padding(.top, -5)
             }
             
-            /// 구성원 추가
+            // 구성원 추가
             HStack(spacing: 20) {
                 TextField("학번", text: $viewModel.newMemberStudentNum)
                     .font(.custom("GmarketSansLight", size: 14))
@@ -33,7 +33,7 @@ struct AdminMemberView: View {
                     .focused($isFocused)
                     .overlay(
                         RoundedRectangle(cornerRadius: 10)
-                            .stroke(isFocused ? Color.softBlue : Color.gray.opacity(0.2), lineWidth: 1.5)
+                            .stroke(isFocused ? Color.darkNavy : Color.gray.opacity(0.2), lineWidth: 1.5)
                     )
                 TextField("이름", text: $viewModel.newMemberName)
                     .font(.custom("GmarketSansLight", size: 14))
@@ -41,7 +41,7 @@ struct AdminMemberView: View {
                     .focused($isFocused)
                     .overlay(
                         RoundedRectangle(cornerRadius: 10)
-                            .stroke(isFocused ? Color.softBlue : Color.gray.opacity(0.2), lineWidth: 1.5)
+                            .stroke(isFocused ? Color.darkNavy : Color.gray.opacity(0.2), lineWidth: 1.5)
                     )
                 
                 Button(action: {
@@ -56,13 +56,13 @@ struct AdminMemberView: View {
                         .foregroundColor(.white)
                         .padding(.horizontal, 15)
                         .padding(.vertical, 8)
-                        .background(Color.deposit)
+                        .background(Color.darkNavy)
                         .cornerRadius(8)
                 }
             }
             .padding(.bottom, 20)
 
-            /// 구성원 목록
+            // 구성원 목록
             if !viewModel.members.isEmpty {
                 VStack(spacing: 0) {
                     ForEach(viewModel.members) { member in

--- a/ToMyongJi-iOS/Features/Admin/Views/President/AdminPresidentView.swift
+++ b/ToMyongJi-iOS/Features/Admin/Views/President/AdminPresidentView.swift
@@ -45,7 +45,7 @@ struct AdminPresidentView: View {
                     .focused($isFocused)
                     .overlay(
                         RoundedRectangle(cornerRadius: 10)
-                            .stroke(isFocused ? Color.softBlue : Color.gray.opacity(0.2), lineWidth: 1.5)
+                            .stroke(isFocused ? Color.darkNavy : Color.gray.opacity(0.2), lineWidth: 1.5)
                     )
                 TextField("이름", text: $viewModel.newPresidentName)
                     .font(.custom("GmarketSansLight", size: 14))
@@ -53,7 +53,7 @@ struct AdminPresidentView: View {
                     .focused($isFocused)
                     .overlay(
                         RoundedRectangle(cornerRadius: 10)
-                            .stroke(isFocused ? Color.softBlue : Color.gray.opacity(0.2), lineWidth: 1.5)
+                            .stroke(isFocused ? Color.darkNavy : Color.gray.opacity(0.2), lineWidth: 1.5)
                     )
                 
                 Button {
@@ -86,7 +86,7 @@ struct AdminPresidentView: View {
                         .foregroundColor(.white)
                         .padding(.horizontal, 15)
                         .padding(.vertical, 8)
-                        .background(Color.deposit)
+                        .background(Color.darkNavy)
                         .cornerRadius(8)
                 }
             }

--- a/ToMyongJi-iOS/Features/FindID/Views/FindIDView.swift
+++ b/ToMyongJi-iOS/Features/FindID/Views/FindIDView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct FindIDView: View {
     @Environment(\.dismiss) private var dismiss
     @Bindable private var viewModel: FindIDViewModel = FindIDViewModel()
+    @FocusState private var isFocused: Bool
     
     var body: some View {
         VStack(alignment: .leading, spacing: 15) {
@@ -32,15 +33,39 @@ struct FindIDView: View {
                 .foregroundStyle(.gray)
                 .padding(.top, -5)
             
-            VStack(spacing: 25) {
-                CustomTF(sfIcon: "at", hint: "이메일 주소", value: $viewModel.email)
-                
-                GradientButton(title: "아이디 찾기", icon: "chevron.right") {
-                    viewModel.findID()
-                }
-                .hSpacing(.trailing)
-                .disableWithOpacity(viewModel.email.isEmpty)
+            // 입력 필드를 감싸는 카드 뷰
+            VStack(spacing: 0) {
+                TextField("이메일 주소", text: $viewModel.email)
+                    .font(.custom("GmarketSansLight", size: 15))
+                    .padding()
+                    .focused($isFocused)
+                    .submitLabel(.done)
+                    .keyboardType(.emailAddress)
+                    .autocapitalization(.none)
+                    .onSubmit {
+                        viewModel.findID()
+                    }
             }
+            .background(Color.gray.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .padding(.top, 20)
+            
+            // 아이디 찾기 버튼
+            Button(action: {
+                viewModel.findID()
+            }) {
+                Text("아이디 찾기")
+                    .font(.custom("GmarketSansMedium", size: 16))
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 15)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color.darkNavy)
+                            .opacity(viewModel.email.isEmpty ? 0.5 : 1)
+                    )
+            }
+            .disabled(viewModel.email.isEmpty)
             .padding(.top, 20)
         }
         .padding(.vertical, 15)

--- a/ToMyongJi-iOS/Features/Login/Views/LoginView.swift
+++ b/ToMyongJi-iOS/Features/Login/Views/LoginView.swift
@@ -13,6 +13,12 @@ struct LoginView: View {
     @Bindable private var authManager = AuthenticationManager.shared
     @Binding var showSignup: Bool
     @State private var showFindIdView: Bool = false
+    @FocusState private var focusField: Field?
+    
+    enum Field {
+        case id
+        case password
+    }
     
     var body: some View {
         VStack(spacing: 20) {
@@ -23,17 +29,50 @@ struct LoginView: View {
                 .frame(width: 200)
                 .padding(.vertical, 50)
             
-            // 아이디 입력
-            CustomTF(sfIcon: "person", hint: "아이디를 입력해주세요.", value: $viewModel.userId)
-            
-            // 비밀번호 입력
-            CustomTF(sfIcon: "lock", hint: "비밀번호를 입력해주세요.", isPassword: true, value: $viewModel.password)
+            // 입력 필드들을 감싸는 카드 뷰
+            VStack(spacing: 0) {
+                // 아이디 입력
+                TextField("아이디 또는 전화번호", text: $viewModel.userId)
+                    .font(.custom("GmarketSansLight", size: 15))
+                    .padding()
+                    .focused($focusField, equals: .id)
+                    .submitLabel(.next)
+                    .onSubmit {
+                        focusField = .password
+                    }
+                
+                Divider()
+                    .background(Color.gray.opacity(0.2))
+                
+                // 비밀번호 입력
+                SecureField("비밀번호", text: $viewModel.password)
+                    .font(.custom("GmarketSansLight", size: 15))
+                    .padding()
+                    .focused($focusField, equals: .password)
+                    .submitLabel(.done)
+                    .onSubmit {
+                        viewModel.login()
+                    }
+            }
+            .background(Color.gray.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
             
             // 로그인 버튼
-            GradientButton(title: "로그인", icon: "arrow.right") {
+            Button(action: {
                 viewModel.login()
+            }) {
+                Text("로그인")
+                    .font(.custom("GmarketSansMedium", size: 16))
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 15)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color.darkNavy)
+                            .opacity(viewModel.userId.isEmpty || viewModel.password.isEmpty ? 0.5 : 1)
+                    )
             }
-            .disableWithOpacity(viewModel.userId.isEmpty || viewModel.password.isEmpty || viewModel.isLoading)
+            .disabled(viewModel.userId.isEmpty || viewModel.password.isEmpty || viewModel.isLoading)
             .padding(.top, 20)
             
             // 회원가입 및 아이디 찾기 버튼

--- a/ToMyongJi-iOS/Features/Main/Views/AdminTabView.swift
+++ b/ToMyongJi-iOS/Features/Main/Views/AdminTabView.swift
@@ -28,7 +28,7 @@ struct AdminTabView: View {
                     }
                     .tag(2)
             }
-            .tint(Color.softBlue)
+            .tint(Color.darkNavy)
             // 토큰 만료 알림 추가
             .alert("세션 만료", isPresented: $showTokenExpiredAlert) {
                 Button("확인") {

--- a/ToMyongJi-iOS/Features/Main/Views/MainTabView.swift
+++ b/ToMyongJi-iOS/Features/Main/Views/MainTabView.swift
@@ -72,7 +72,7 @@ struct MainTabView: View {
                 }
                 .tag(3)
             }
-            .tint(Color.softBlue)
+            .tint(Color.darkNavy)
             .navigationBarBackButtonHidden()
             .alert("로그인 후 이용 가능합니다.", isPresented: $showLoginAlert) {
                 Button("취소", role: .cancel) {

--- a/ToMyongJi-iOS/Features/Profile/Views/AddClubMemberRow.swift
+++ b/ToMyongJi-iOS/Features/Profile/Views/AddClubMemberRow.swift
@@ -25,7 +25,7 @@ struct AddClubMemberRow: View {
                     .foregroundColor(.white)
                     .padding(.horizontal, 15)
                     .padding(.vertical, 8)
-                    .background(Color.deposit)
+                    .background(Color.darkNavy)
                     .cornerRadius(8)
             }
         }

--- a/ToMyongJi-iOS/Features/SignUp/Views/InputViews/InputClubAuthenticationView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/InputViews/InputClubAuthenticationView.swift
@@ -134,7 +134,7 @@ struct InputClubAuthenticationView: View {
             }
             .frame(maxWidth: .infinity, alignment: .center)
             .padding(.vertical, 15)
-            .background(isFormValid ? Color.softBlue : Color.gray.opacity(0.3))
+            .background(isFormValid ? Color.darkNavy : Color.gray.opacity(0.3))
             .clipShape(RoundedRectangle(cornerRadius: 10))
             .disabled(!isFormValid)
             
@@ -149,7 +149,7 @@ struct InputClubAuthenticationView: View {
             }
             .frame(maxWidth: .infinity, alignment: .center)
             .padding(.vertical, 15)
-            .background(viewModel.isClubVerified ? Color.softBlue : Color.gray.opacity(0.3))
+            .background(viewModel.isClubVerified ? Color.darkNavy : Color.gray.opacity(0.3))
             .clipShape(RoundedRectangle(cornerRadius: 10))
             .disabled(!viewModel.isClubVerified)
         }

--- a/ToMyongJi-iOS/Features/SignUp/Views/InputViews/InputEmailView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/InputViews/InputEmailView.swift
@@ -72,7 +72,7 @@ struct InputEmailView: View {
                             .foregroundStyle(.white)
                             .padding(.horizontal, 15)
                             .padding(.vertical, 15)
-                            .background(email.isEmpty ? Color.gray.opacity(0.3) : Color.softBlue)
+                            .background(email.isEmpty ? Color.gray.opacity(0.3) : Color.darkNavy)
                             .clipShape(RoundedRectangle(cornerRadius: 10))
                     }
                     .disabled(email.isEmpty || !isValidEmail(email))
@@ -97,7 +97,7 @@ struct InputEmailView: View {
                                 .foregroundStyle(.white)
                                 .padding(.horizontal, 15)
                                 .padding(.vertical, 15)
-                                .background(verificationCode.count != 8 ? Color.gray.opacity(0.3) : Color.softBlue)
+                                .background(verificationCode.count != 8 ? Color.gray.opacity(0.3) : Color.darkNavy)
                                 .clipShape(RoundedRectangle(cornerRadius: 10))
                         }
                         .disabled(verificationCode.count != 8)
@@ -116,7 +116,7 @@ struct InputEmailView: View {
             }
             .frame(maxWidth: .infinity, alignment: .center)
             .padding(.vertical, 15)
-            .background(!isVerified ? Color.gray.opacity(0.3) : Color.softBlue)
+            .background(!isVerified ? Color.gray.opacity(0.3) : Color.darkNavy)
             .clipShape(RoundedRectangle(cornerRadius: 10))
             .disabled(!isVerified)
         }

--- a/ToMyongJi-iOS/Features/SignUp/Views/InputViews/InputIDView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/InputViews/InputIDView.swift
@@ -67,7 +67,7 @@ struct InputIDView: View {
                         .foregroundStyle(.white)
                         .padding(.horizontal, 15)
                         .padding(.vertical, 15)
-                        .background(userId.isEmpty ? Color.gray.opacity(0.3) : Color.softBlue)
+                        .background(userId.isEmpty ? Color.gray.opacity(0.3) : Color.darkNavy)
                         .clipShape(RoundedRectangle(cornerRadius: 10))
                 }
                 .disabled(userId.isEmpty || !isValid)
@@ -94,7 +94,7 @@ struct InputIDView: View {
             }
             .frame(maxWidth: .infinity, alignment: .center)
             .padding(.vertical, 15)
-            .background((!isValid || !isUserIdAvailable) ? Color.gray.opacity(0.3) : Color.softBlue)
+            .background((!isValid || !isUserIdAvailable) ? Color.gray.opacity(0.3) : Color.darkNavy)
             .clipShape(RoundedRectangle(cornerRadius: 10))
             .disabled(!isValid || !isUserIdAvailable)
         }

--- a/ToMyongJi-iOS/Features/SignUp/Views/InputViews/InputPasswordView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/InputViews/InputPasswordView.swift
@@ -113,7 +113,7 @@ struct InputPasswordView: View {
             }
             .frame(maxWidth: .infinity, alignment: .center)
             .padding(.vertical, 15)
-            .background(!isPasswordValid ? Color.gray.opacity(0.3) : Color.softBlue)
+            .background(!isPasswordValid ? Color.gray.opacity(0.3) : Color.darkNavy)
             .clipShape(RoundedRectangle(cornerRadius: 10))
             .disabled(!isPasswordValid)
         }

--- a/ToMyongJi-iOS/Features/SignUp/Views/SignUpAgree/SignUpAgreeView.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/SignUpAgree/SignUpAgreeView.swift
@@ -106,7 +106,7 @@ struct SignUpAgreeView: View {
             .background(
                 (!isAgreeService || !isAgreePrivacy || !isAgreeClub)
                 ? Color.gray.opacity(0.3)
-                : Color.softBlue
+                : Color.darkNavy
             )
             .clipShape(RoundedRectangle(cornerRadius: 10))
             .disabled(!isAgreeService || !isAgreePrivacy || !isAgreeClub)

--- a/ToMyongJi-iOS/Features/SignUp/Views/SignUpTextField.swift
+++ b/ToMyongJi-iOS/Features/SignUp/Views/SignUpTextField.swift
@@ -65,7 +65,7 @@ struct SignUpTextField: View {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
-                    .stroke(isFocused || (isPassword && passwordState != nil) ? Color.softBlue : Color.gray.opacity(0.2), lineWidth: 1)
+                    .stroke(isFocused || (isPassword && passwordState != nil) ? Color.darkNavy : Color.gray.opacity(0.2), lineWidth: 1)
             )
             .animation(.easeInOut(duration: 0.2), value: isFocused)
         }

--- a/ToMyongJi-iOS/Features/SplashScreen/Views/SplashScreenView.swift
+++ b/ToMyongJi-iOS/Features/SplashScreen/Views/SplashScreenView.swift
@@ -31,7 +31,7 @@ struct SplashScreenView: View {
                     .padding(.bottom, 30)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.softBlue)
+            .background(Color.white)
             .opacity(opacity)
             .onAppear {
                 withAnimation(.easeIn(duration: 1.5)) {


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #60 

### 📝작업 내용

> Login, SignUp, FindID 레이아웃 및 tint 색상 수정
- 전체적인 버튼, tint 색상 수정
- 로그인, 회원가입, 아이디찾기 레이아웃 및 버튼 색상 통일

### 🔨테스트 결과 > 스크린샷 (선택)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-16 at 20 25 36](https://github.com/user-attachments/assets/3c7111f3-928c-46df-97f5-db225ab81187)

![Simulator Screenshot - iPhone 16 Pro - 2025-03-16 at 20 25 42](https://github.com/user-attachments/assets/d61e8094-ae3c-42bd-bbc8-e08d7af26398)

![Simulator Screenshot - iPhone 16 Pro - 2025-03-16 at 20 25 48](https://github.com/user-attachments/assets/a4384e5e-5a4f-42e5-a790-1ee75146d999)

