### PR TITLE
Fix: darkMode 방지 및 Login UI 개선

### DIFF
--- a/App/Resources/Info.plist
+++ b/App/Resources/Info.plist
@@ -2,6 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.tomyongji.ios</string>
+	<key>CFBundleName</key>
+	<string>ToMyongJi</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
@@ -13,19 +25,9 @@
 		<string>GmarketSansMedium.otf</string>
 		<string>GmarketSansLight.otf</string>
 	</array>
-	<key>CFBundleIdentifier</key>
-	<string>com.tomyongji.ios</string>
-	<key>CFBundleVersion</key>
-	<string>1</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
-	<key>CFBundleName</key>
-	<string>ToMyongJi</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
 	<key>UILaunchScreen</key>
 	<dict/>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/Feature/Sources/Login/Views/LoginView.swift
+++ b/Feature/Sources/Login/Views/LoginView.swift
@@ -15,6 +15,7 @@ struct LoginView: View {
     @Binding var showSignup: Bool
     @State private var showFindIdView: Bool = false
     @FocusState private var focusField: Field?
+    @State private var keyboardHeight: CGFloat = 0
     
     enum Field {
         case id
@@ -22,92 +23,99 @@ struct LoginView: View {
     }
     
     var body: some View {
-        VStack(spacing: 20) {
-            Button(action: {
-                dismiss()
-                if let tabSelection = UserDefaults.standard.value(forKey: "selectedTab") as? Int {
-                    UserDefaults.standard.set(1, forKey: "selectedTab")
-                }
-            }) {
-                Image(systemName: "chevron.left")
-                    .font(.title3.bold())
-                    .foregroundStyle(Color.darkNavy)
-                    .contentShape(.rect)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            Spacer()
-            // 로고 이미지
-            Image("logo")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 200)
-                .padding(.vertical, 50)
-            
-            // 입력 필드들을 감싸는 카드 뷰
-            VStack(spacing: 0) {
-                // 아이디 입력
-                TextField("아이디", text: $viewModel.userId)
-                    .font(.custom("GmarketSansLight", size: 15))
-                    .padding()
-                    .focused($focusField, equals: .id)
-                    .submitLabel(.next)
-                    .onSubmit {
-                        focusField = .password
+        ScrollView {
+            VStack(spacing: 20) {
+                Button(action: {
+                    dismiss()
+                    if let tabSelection = UserDefaults.standard.value(forKey: "selectedTab") as? Int {
+                        UserDefaults.standard.set(1, forKey: "selectedTab")
                     }
+                }) {
+                    Image(systemName: "chevron.left")
+                        .font(.title3.bold())
+                        .foregroundStyle(Color.darkNavy)
+                        .contentShape(.rect)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
                 
-                Divider()
-                    .background(Color.gray.opacity(0.2))
+                Spacer()
+                    .frame(height: 50)
                 
-                // 비밀번호 입력
-                SecureField("비밀번호", text: $viewModel.password)
-                    .font(.custom("GmarketSansLight", size: 15))
-                    .padding()
-                    .focused($focusField, equals: .password)
-                    .submitLabel(.done)
-                    .onSubmit {
-                        viewModel.login()
+                // 로고 이미지 - 크기 유지
+                Image("logo")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 300)
+                    .padding(.vertical, 50)
+                
+                // 입력 필드들을 감싸는 카드 뷰
+                VStack(spacing: 0) {
+                    // 아이디 입력
+                    TextField("아이디", text: $viewModel.userId)
+                        .font(.custom("GmarketSansLight", size: 15))
+                        .padding()
+                        .focused($focusField, equals: .id)
+                        .submitLabel(.next)
+                        .onSubmit {
+                            focusField = .password
+                        }
+                    
+                    Divider()
+                        .background(Color.gray.opacity(0.2))
+                    
+                    // 비밀번호 입력
+                    SecureField("비밀번호", text: $viewModel.password)
+                        .font(.custom("GmarketSansLight", size: 15))
+                        .padding()
+                        .focused($focusField, equals: .password)
+                        .submitLabel(.done)
+                        .onSubmit {
+                            viewModel.login()
+                        }
+                }
+                .background(Color.gray.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                
+                // 로그인 버튼
+                Button(action: {
+                    viewModel.login()
+                }) {
+                    Text("로그인")
+                        .font(.custom("GmarketSansMedium", size: 16))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 15)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color.darkNavy)
+                                .opacity(viewModel.userId.isEmpty || viewModel.password.isEmpty ? 0.1 : 1)
+                        )
+                }
+                .disabled(viewModel.userId.isEmpty || viewModel.password.isEmpty || viewModel.isLoading)
+                .padding(.top, 20)
+                
+                // 회원가입 및 아이디 찾기 버튼
+                HStack(spacing: 12) {
+                    Button("회원가입") {
+                        showSignup = true
                     }
-            }
-            .background(Color.gray.opacity(0.1))
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            
-            // 로그인 버튼
-            Button(action: {
-                viewModel.login()
-            }) {
-                Text("로그인")
-                    .font(.custom("GmarketSansMedium", size: 16))
-                    .foregroundColor(.white)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 15)
-                    .background(
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(Color.darkNavy)
-                            .opacity(viewModel.userId.isEmpty || viewModel.password.isEmpty ? 0.1 : 1)
-                    )
-            }
-            .disabled(viewModel.userId.isEmpty || viewModel.password.isEmpty || viewModel.isLoading)
-            .padding(.top, 20)
-            
-            // 회원가입 및 아이디 찾기 버튼
-            HStack(spacing: 12) {
-                Button("회원가입") {
-                    showSignup = true
+                    
+                    Button("아이디 찾기") {
+                        showFindIdView = true
+                    }
                 }
+                .font(.custom("GmarketSansMedium", size: 13))
+                .tint(.gray)
+                .padding(.top, 15)
                 
-                Button("아이디 찾기") {
-                    showFindIdView = true
-                }
+                Spacer()
+                    .frame(height: 50)
             }
-            .font(.custom("GmarketSansMedium", size: 13))
-            .tint(.gray)
-            .padding(.top, 15)
-            Spacer()
-            Spacer()
-            Spacer()
+            .padding(.horizontal, 25)
+            .padding(.vertical, 15)
         }
-        .padding(.horizontal, 25)
-        .padding(.vertical, 15)
+        .scrollDismissesKeyboard(.immediately)
+        .ignoresSafeArea(.keyboard)
         .sheet(isPresented: $showFindIdView, content: {
             FindIDView()
                 .presentationDetents([.height(300)])


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #60 

### 📝작업 내용

> 다크 모드 방지 및 로그인 UI 개선
- info -> custom ios target properties -> appearance의 속성으로 Light
- Login의 keyboard height 지정, scrollview 설정을 통한 로고 이미지 리사이즈 방지

