### PR TITLE
Feat: 서버 점검 대응을 위한 root view 변경

### DIFF
--- a/App/Sources/ContentView.swift
+++ b/App/Sources/ContentView.swift
@@ -10,7 +10,8 @@ import Feature
 
 public struct ContentView: View {
     public var body: some View {
-        MainTabView()
+        MaintenanceView()
+//        MainTabView()
 //        IntroView()
     }
 }

--- a/App/Sources/MaintenanceView.swift
+++ b/App/Sources/MaintenanceView.swift
@@ -1,0 +1,98 @@
+//
+//  MaintenanceView.swift
+//  ToMyongJi-iOS
+//
+//  Created by JunKyu Lee on 3/21/25.
+//  Copyright © 2025 ToMyongJi. All rights reserved.
+//
+
+import SwiftUI
+
+struct MaintenanceView: View {
+    var body: some View {
+        VStack(spacing: 30) {
+            // 상단 아이콘
+            ZStack {
+                Circle()
+                    .fill(Color.darkNavy)
+                    .overlay {
+                        Circle()
+                            .fill(.white.opacity(0.2))
+                    }
+                    .frame(width: 120, height: 120)
+                
+                Image(systemName: "wrench.and.screwdriver.fill")
+                    .font(.system(size: 50))
+                    .foregroundStyle(.white)
+            }
+            .padding(.top, 50)
+            
+            // 제목
+            VStack(alignment: .leading, spacing: 10) {
+                Text("서버 점검 안내")
+                    .font(.custom("GmarketSansBold", size: 28))
+                    .foregroundStyle(Color.darkNavy)
+                Text("더 나은 서비스로 곧 돌아오겠습니다.")
+                    .font(.custom("GmarketSansLight", size: 14))
+                    .foregroundStyle(Color.darkNavy)
+            }
+            Spacer()
+                .frame(height: 10)
+            
+            // 점검 정보 카드
+            VStack(alignment: .leading, spacing: 30) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("점검 일시")
+                        .font(.custom("GmarketSansMedium", size: 16))
+                        .foregroundStyle(Color.darkNavy)
+                    Text("3월 21일 17:00 ~ 3월 22일 09:00")
+                        .font(.custom("GmarketSansBold", size: 16))
+                        .foregroundStyle(Color.darkNavy)
+                }
+                
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("점검 내용")
+                        .font(.custom("GmarketSansMedium", size: 16))
+                        .foregroundStyle(Color.darkNavy)
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text("• 서버 성능 개선 및 안정화")
+                    }
+                    .font(.custom("GmarketSansLight", size: 14))
+                    .foregroundStyle(Color.darkNavy)
+                }
+                
+                Text("점검 중에는 서비스 이용이 일시 중단됩니다.")
+                    .font(.custom("GmarketSansLight", size: 14))
+                    .foregroundStyle(Color.darkNavy)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 10)
+            }
+            .padding(25)
+            .background(
+                RoundedRectangle(cornerRadius: 25, style: .continuous)
+                    .fill(Color.softBlue)
+                    .overlay(alignment: .leading) {
+                        Circle()
+                            .fill(Color.softBlue)
+                            .overlay {
+                                Circle()
+                                    .fill(.white.opacity(0.2))
+                            }
+                            .scaleEffect(2, anchor: .topLeading)
+                            .offset(x: -50, y: -40)
+                    }
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 25, style: .continuous))
+            .padding(.horizontal, 20)
+            
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(uiColor: .systemGroupedBackground))
+    }
+}
+
+#Preview {
+    MaintenanceView()
+}

--- a/ToMyongJi.xcodeproj/project.pbxproj
+++ b/ToMyongJi.xcodeproj/project.pbxproj
@@ -98,6 +98,8 @@
 		ED5F6DFCD9689DA389D955CC /* SignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D17CE094C7BEB4989CB0B4E /* SignUpViewModel.swift */; };
 		EDEFA92BC378015189D631CC /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7248833B0B474A3E68148 /* Profile.swift */; };
 		F4EB170199274A58AE9AE01F /* Feature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 79E57EC36E48D72F62A7553D /* Feature.framework */; };
+		F528F7B32D8D7B17001EB483 /* MaintenanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F528F7B22D8D7B17001EB483 /* MaintenanceView.swift */; };
+		F528F7B42D8D7B17001EB483 /* MaintenanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F528F7B22D8D7B17001EB483 /* MaintenanceView.swift */; };
 		F9AC321504DCA3B777E4C24E /* GmarketSansLight.otf in Resources */ = {isa = PBXBuildFile; fileRef = 57B6773E9601E7C09856D053 /* GmarketSansLight.otf */; };
 		F9ECD81A463A5A27C2913648 /* President.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B0BAA7C7F713CF97BC2D86 /* President.swift */; };
 		FB8458E067B06264C0A12800 /* Feature.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 79E57EC36E48D72F62A7553D /* Feature.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -302,6 +304,7 @@
 		E9D55CD4AA05D94B5AAEA1C0 /* CollegesAndClubsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollegesAndClubsViewModel.swift; sourceTree = "<group>"; };
 		ECE4A5D80FD0B1BD968309D3 /* AgreeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgreeButton.swift; sourceTree = "<group>"; };
 		F282863C267985B3BA98494A /* AgreementType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgreementType.swift; sourceTree = "<group>"; };
+		F528F7B22D8D7B17001EB483 /* MaintenanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceView.swift; sourceTree = "<group>"; };
 		F5297ADE6F65CF8664EC4D05 /* IntroViewItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewItem.swift; sourceTree = "<group>"; };
 		F7723E6305C721829635E7F6 /* TuistBundle+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistBundle+UI.swift"; sourceTree = "<group>"; };
 		F8C703DC525E6154C8D0364C /* UI-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "UI-Info.plist"; sourceTree = "<group>"; };
@@ -879,6 +882,7 @@
 		D23909B2AAE71BB9BD1D38C8 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				F528F7B22D8D7B17001EB483 /* MaintenanceView.swift */,
 				B942DFCDEF3AA88E2818E77E /* ContentView.swift */,
 				0434389C67FC072619AA1FD0 /* SplashScreenView.swift */,
 				83AF01502CD02A7884EB6964 /* ToMyongJi_iOSApp.swift */,
@@ -1265,6 +1269,7 @@
 				FDB8C991ABD9B952EBC45B45 /* CreateReceiptFormView.swift in Sources */,
 				FDDF8D2E806619E818A6AECA /* CreateReceiptView.swift in Sources */,
 				52599826619CE750A8DBC1DA /* ReceiptListView.swift in Sources */,
+				F528F7B32D8D7B17001EB483 /* MaintenanceView.swift in Sources */,
 				5A51C8F20F9AF46401549F4B /* AgreementType.swift in Sources */,
 				825DED37FBF7F130E06F181E /* SignUp.swift in Sources */,
 				15AC8737B62235755ED0D214 /* SignUpEndpoint.swift in Sources */,
@@ -1288,6 +1293,7 @@
 				32C320C79D21092DA1B8D2A4 /* ContentView.swift in Sources */,
 				2E19C451AACCC1767B2BB932 /* SplashScreenView.swift in Sources */,
 				354DE0104D5E485A68E084AE /* ToMyongJi_iOSApp.swift in Sources */,
+				F528F7B42D8D7B17001EB483 /* MaintenanceView.swift in Sources */,
 				0837F86D652FB69BF24DDDFA /* TuistAssets+ToMyongJiIOS.swift in Sources */,
 				AC76142CA39EADAEA1CC6C91 /* TuistBundle+ToMyongJiIOS.swift in Sources */,
 				7237D0EF284D9A7E02303118 /* TuistFonts+ToMyongJiIOS.swift in Sources */,


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #78 

### 📝작업 내용

> 서버 점검 대응을 위한 root view 변경

### 🔨테스트 결과 > 스크린샷 (선택)

![Simulator Screenshot - iPhone 16 Pro - 2025-03-21 at 20 02 46](https://github.com/user-attachments/assets/855f3aa8-b323-4ce7-ab1b-9395c84b573b)

