### PR TITLE
Fix: Project.swift development darget iOS 16.0으로 수정

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -22,7 +22,8 @@ let project = Project(
                 .target(name: "Core"),
                 .target(name: "Feature"),
                 .target(name: "UI")
-            ]
+            ],
+            deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone, .ipad])
         ),
         .target(
             name: "App",
@@ -35,7 +36,8 @@ let project = Project(
                 .target(name: "Core"),
                 .target(name: "UI"),
                 .target(name: "Feature")
-            ]
+            ],
+            deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone, .ipad])
         ),
         .target(
             name: "Feature",
@@ -47,7 +49,8 @@ let project = Project(
             dependencies: [
                 .target(name: "Core"),
                 .target(name: "UI")
-            ]
+            ],
+            deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone, .ipad])
         ),
         .target(
             name: "Core",
@@ -58,7 +61,8 @@ let project = Project(
             sources: ["Core/Sources/**"],
             dependencies: [
                 .package(product: "Alamofire")
-            ]
+            ],
+            deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone, .ipad])
         ),
         .target(
             name: "UI",
@@ -70,7 +74,8 @@ let project = Project(
             resources: [
                 "UI/Resources/Assets.xcassets",
                 "UI/Resources/Fonts/**"
-            ]
+            ],
+            deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone, .ipad])
         )
     ]
-) 
+)


### PR DESCRIPTION
# 🫧투명지 PR🫧

### 📝작업 내용

> Project.swift development darget iOS 16.0으로 수정
- 각각의 모듈의 최소 지원 버전 18.2 -> 16.0

