### PR TITLE
Chore: Core-Network 테스트 코드를 위한 tuist Project.swift 세팅

### DIFF
--- a/Core/Tests/Network/AlamofireNetworkingManagerTests.swift
+++ b/Core/Tests/Network/AlamofireNetworkingManagerTests.swift
@@ -1,0 +1,16 @@
+//
+//  AlamofireNetworkingManagerTests.swift
+//  ToMyongJi-iOS
+//
+//  Created by JunKyu Lee on 3/25/25.
+//  Copyright © 2025 ToMyongJi. All rights reserved.
+//
+
+import XCTest
+import Alamofire
+import Combine
+@testable import Core
+
+final class AlamofireNetworkingManagerTests: XCTestCase {
+    
+}

--- a/Derived/InfoPlists/CoreTests-Info.plist
+++ b/Derived/InfoPlists/CoreTests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Project.swift
+++ b/Project.swift
@@ -22,8 +22,7 @@ let project = Project(
                 .target(name: "Core"),
                 .target(name: "Feature"),
                 .target(name: "UI")
-            ],
-            deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone, .ipad])
+            ]
         ),
         .target(
             name: "App",
@@ -36,8 +35,7 @@ let project = Project(
                 .target(name: "Core"),
                 .target(name: "UI"),
                 .target(name: "Feature")
-            ],
-            deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone, .ipad])
+            ]
         ),
         .target(
             name: "Feature",
@@ -49,8 +47,7 @@ let project = Project(
             dependencies: [
                 .target(name: "Core"),
                 .target(name: "UI")
-            ],
-            deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone, .ipad])
+            ]
         ),
         .target(
             name: "Core",
@@ -61,8 +58,7 @@ let project = Project(
             sources: ["Core/Sources/**"],
             dependencies: [
                 .package(product: "Alamofire")
-            ],
-            deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone, .ipad])
+            ]
         ),
         .target(
             name: "UI",
@@ -74,8 +70,18 @@ let project = Project(
             resources: [
                 "UI/Resources/Assets.xcassets",
                 "UI/Resources/Fonts/**"
-            ],
-            deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone, .ipad])
+            ]
+        ),
+        .target(
+            name: "CoreTests",
+            destinations: [.iPhone, .iPad],
+            product: .unitTests,
+            bundleId: "com.tomyongji.coreTests",
+            infoPlist: .extendingDefault(with: [:]),
+            sources: ["Core/Tests/**"],
+            dependencies: [
+                .target(name: "Core")
+            ]
         )
     ]
 )

--- a/ToMyongJi.xcodeproj/project.pbxproj
+++ b/ToMyongJi.xcodeproj/project.pbxproj
@@ -32,11 +32,13 @@
 		354DE0104D5E485A68E084AE /* ToMyongJi_iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83AF01502CD02A7884EB6964 /* ToMyongJi_iOSApp.swift */; };
 		388E9E5DD16CF696991900C3 /* FindIDEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A6CAB10EAD33EE3A98FC25 /* FindIDEndpoint.swift */; };
 		39EB0148288295492FD9840A /* GmarketSansLight.otf in Resources */ = {isa = PBXBuildFile; fileRef = 57B6773E9601E7C09856D053 /* GmarketSansLight.otf */; };
+		3BE7E7D4A7BD5BA5658F06FD /* MaintenanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BE8A3EFF47B1A47D5DAA28 /* MaintenanceView.swift */; };
 		3D0CCD9D5E3EE45E11478376 /* AddClubMemberRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D2E0AB107A9C0689AA58B0 /* AddClubMemberRow.swift */; };
 		3F0C42457582B73A1210E8D6 /* CollegesAndClubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC04466725ECCF5FD070BAD5 /* CollegesAndClubs.swift */; };
 		3FC268FB69EEBB7C85D4C4BD /* AuthenticationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A770C1C085DFD23EC9DDFCE1 /* AuthenticationView.swift */; };
 		3FC2BED5897CD08922ADC6DF /* AdminMemberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB67AA4001FB03B93725ADB /* AdminMemberView.swift */; };
 		421C1E70461573CC26802BA5 /* AgreeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE4A5D80FD0B1BD968309D3 /* AgreeButton.swift */; };
+		439B1E0DDAC7DDCFD4661D45 /* MonthPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6502D342639F99F469DFFD /* MonthPickerView.swift */; };
 		4717D3205BEBECFF15468204 /* SignUpAgreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131942CF256661618987D380 /* SignUpAgreeView.swift */; };
 		4768A3DC7C1892F0FA9B49CF /* GmarketSansBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7F4EE414B972F985522AAC3F /* GmarketSansBold.otf */; };
 		50AD9E71978D1F56DB597DF9 /* InputEmailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B5171995BA262DFC700D09 /* InputEmailView.swift */; };
@@ -46,6 +48,7 @@
 		5CBB5FC938B0CAC729597095 /* CollegesAndClubsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D55CD4AA05D94B5AAEA1C0 /* CollegesAndClubsViewModel.swift */; };
 		5D50D5C1D66556849D72355B /* Core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4E6E6FA698BFDCA48CBC1A58 /* Core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6195E2C6FA03447BC528C318 /* Member.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA71563932CA9E6352A4ADA /* Member.swift */; };
+		620DD781A254D52968A410EA /* MaintenanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BE8A3EFF47B1A47D5DAA28 /* MaintenanceView.swift */; };
 		68E346E2B289C8CB2B31D0EB /* FindIDViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CAB29479DAB0B01451A917 /* FindIDViewModel.swift */; };
 		6AC31C5035D1BFF8CDEC2E36 /* SelectCollegesAndClubsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE47F37DC5E4D08AA9C53989 /* SelectCollegesAndClubsView.swift */; };
 		6B8798819637BA7CC6A6354B /* ClubMember.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B5A5DEAEB591BDDCCF9034 /* ClubMember.swift */; };
@@ -58,6 +61,7 @@
 		7CAC1F4CFDFFF3870E728CFB /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E6E6FA698BFDCA48CBC1A58 /* Core.framework */; };
 		7DE4F440B33C6CE1E062F02E /* UI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 26515D53170FF30DD2863442 /* UI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7DF6E35A2E3199D11A058BD7 /* Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71751B06873D373A696F7819 /* Login.swift */; };
+		817E555668379DF5AE7EC7A7 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E6E6FA698BFDCA48CBC1A58 /* Core.framework */; };
 		825DED37FBF7F130E06F181E /* SignUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34393AA46DA94451CF788592 /* SignUp.swift */; };
 		84134D8C0DA9D1ACDAAD0FF4 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FA747C07CE18E92DB1383C /* ProfileView.swift */; };
 		85C7BF3401BA7EA5031392A5 /* GmarketSansMedium.otf in Resources */ = {isa = PBXBuildFile; fileRef = CBEFE4CBD3A375C18679F105 /* GmarketSansMedium.otf */; };
@@ -84,6 +88,7 @@
 		CE0BBF96C0CDBBDB39FE37C0 /* AdminPresidentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B14476FFBA7E4A7E3574445 /* AdminPresidentView.swift */; };
 		CEDE43057722CC0380F18A33 /* Feature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 79E57EC36E48D72F62A7553D /* Feature.framework */; };
 		D26501B69E5A7332ECA7A9A7 /* ToMyongJi_iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83AF01502CD02A7884EB6964 /* ToMyongJi_iOSApp.swift */; };
+		D3A04BC842373FF7FE3FCC12 /* AlamofireNetworkingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B36A6E676E49FF5251075A3 /* AlamofireNetworkingManagerTests.swift */; };
 		D98E6C5D30546329432A83A6 /* GmarketSansBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7F4EE414B972F985522AAC3F /* GmarketSansBold.otf */; };
 		DA348B4B7DD104587DD27786 /* TuistFonts+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB199665032EC73F88149783 /* TuistFonts+UI.swift */; };
 		DADCF523967B11CF4130BBB5 /* View+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BAD61A4B69A7EEF15E6F691 /* View+Extensions.swift */; };
@@ -98,9 +103,6 @@
 		ED5F6DFCD9689DA389D955CC /* SignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D17CE094C7BEB4989CB0B4E /* SignUpViewModel.swift */; };
 		EDEFA92BC378015189D631CC /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7248833B0B474A3E68148 /* Profile.swift */; };
 		F4EB170199274A58AE9AE01F /* Feature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 79E57EC36E48D72F62A7553D /* Feature.framework */; };
-		F525AD4E2D8FFB1B00CE4D3E /* MonthPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F525AD4D2D8FFB1B00CE4D3E /* MonthPickerView.swift */; };
-		F528F7B32D8D7B17001EB483 /* MaintenanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F528F7B22D8D7B17001EB483 /* MaintenanceView.swift */; };
-		F528F7B42D8D7B17001EB483 /* MaintenanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F528F7B22D8D7B17001EB483 /* MaintenanceView.swift */; };
 		F9AC321504DCA3B777E4C24E /* GmarketSansLight.otf in Resources */ = {isa = PBXBuildFile; fileRef = 57B6773E9601E7C09856D053 /* GmarketSansLight.otf */; };
 		F9ECD81A463A5A27C2913648 /* President.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B0BAA7C7F713CF97BC2D86 /* President.swift */; };
 		FB8458E067B06264C0A12800 /* Feature.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 79E57EC36E48D72F62A7553D /* Feature.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -122,6 +124,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 0B89B129FD7D90DE26960F7E;
 			remoteInfo = Feature;
+		};
+		13215CEB660F1A2F2B15FAC9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9DE9128F1973497FDC82560F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8BFBC7B529ACBD5B074DBED3;
+			remoteInfo = Core;
 		};
 		2676EB98D7F16EB9BFFEF33E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -201,6 +210,16 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C06803E636F352DF0B729708 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C4BFA44B177CBB7453D3C6C9 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -250,6 +269,7 @@
 		35DE83C4476D72332B2BB701 /* FindID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindID.swift; sourceTree = "<group>"; };
 		370ED2ABC6A0B9555D5BFC35 /* IntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroView.swift; sourceTree = "<group>"; };
 		4007B3111D84601BEF7F198F /* TuistAssets+ToMyongJiIOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistAssets+ToMyongJiIOS.swift"; sourceTree = "<group>"; };
+		44ED7F91622732D9D7BB4A23 /* CoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		46CA7CB5A54C35737507324C /* ReceiptEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptEndpoint.swift; sourceTree = "<group>"; };
 		4DDAE4F0006E0A0A87059FAD /* TuistFonts+ToMyongJiIOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistFonts+ToMyongJiIOS.swift"; sourceTree = "<group>"; };
 		4E6E6FA698BFDCA48CBC1A58 /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -258,6 +278,7 @@
 		5641C8AE107F7F5F3EF32CC5 /* CollegesAndClubsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollegesAndClubsView.swift; sourceTree = "<group>"; };
 		56B5171995BA262DFC700D09 /* InputEmailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputEmailView.swift; sourceTree = "<group>"; };
 		57B6773E9601E7C09856D053 /* GmarketSansLight.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = GmarketSansLight.otf; sourceTree = "<group>"; };
+		5B36A6E676E49FF5251075A3 /* AlamofireNetworkingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireNetworkingManagerTests.swift; sourceTree = "<group>"; };
 		5DBFAD8D70C6358B8A1B957E /* CustomTF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTF.swift; sourceTree = "<group>"; };
 		62BC1A30498947A17CB87CD6 /* Color+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extensions.swift"; sourceTree = "<group>"; };
 		69B0BAA7C7F713CF97BC2D86 /* President.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = President.swift; sourceTree = "<group>"; };
@@ -268,6 +289,7 @@
 		76B419841B30D48E82E11143 /* Core-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Core-Info.plist"; sourceTree = "<group>"; };
 		79CAB29479DAB0B01451A917 /* FindIDViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindIDViewModel.swift; sourceTree = "<group>"; };
 		79E57EC36E48D72F62A7553D /* Feature.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Feature.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7B8F3A79294BC6BFD0F9E625 /* CoreTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "CoreTests-Info.plist"; sourceTree = "<group>"; };
 		7DE14F4FA3712F9507E21667 /* TokenService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenService.swift; sourceTree = "<group>"; };
 		7F4EE414B972F985522AAC3F /* GmarketSansBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = GmarketSansBold.otf; sourceTree = "<group>"; };
 		80E87C8AB85A326408CA0556 /* AuthenticationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationManager.swift; sourceTree = "<group>"; };
@@ -302,20 +324,28 @@
 		E1FA747C07CE18E92DB1383C /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		E1FEF8BA716F225963A0D161 /* TuistAssets+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistAssets+UI.swift"; sourceTree = "<group>"; };
 		E9496419038EE7CD9CF6E9F4 /* GradientButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientButton.swift; sourceTree = "<group>"; };
+		E9BE8A3EFF47B1A47D5DAA28 /* MaintenanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceView.swift; sourceTree = "<group>"; };
 		E9D55CD4AA05D94B5AAEA1C0 /* CollegesAndClubsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollegesAndClubsViewModel.swift; sourceTree = "<group>"; };
 		ECE4A5D80FD0B1BD968309D3 /* AgreeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgreeButton.swift; sourceTree = "<group>"; };
 		F282863C267985B3BA98494A /* AgreementType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgreementType.swift; sourceTree = "<group>"; };
-		F525AD4D2D8FFB1B00CE4D3E /* MonthPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthPickerView.swift; sourceTree = "<group>"; };
-		F528F7B22D8D7B17001EB483 /* MaintenanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceView.swift; sourceTree = "<group>"; };
 		F5297ADE6F65CF8664EC4D05 /* IntroViewItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewItem.swift; sourceTree = "<group>"; };
 		F7723E6305C721829635E7F6 /* TuistBundle+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistBundle+UI.swift"; sourceTree = "<group>"; };
 		F8C703DC525E6154C8D0364C /* UI-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "UI-Info.plist"; sourceTree = "<group>"; };
 		F94FA58B29F48CF265E924FE /* Feature-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Feature-Info.plist"; sourceTree = "<group>"; };
 		FBF2FEF8B2CD7A75EA61B52B /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
+		FD6502D342639F99F469DFFD /* MonthPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthPickerView.swift; sourceTree = "<group>"; };
 		FE47F37DC5E4D08AA9C53989 /* SelectCollegesAndClubsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectCollegesAndClubsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		4D4ED60ED788A95753FBFA84 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				817E555668379DF5AE7EC7A7 /* Core.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		59740E1383A96BE84517ED22 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -378,6 +408,14 @@
 				48714EEFC6D34D57B15FB28E /* Frameworks */,
 				D355859041F044F808E802DE /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		0390F904E1F037F08DFFDA45 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				4B789673EBCAA4E188583135 /* Network */,
+			);
+			path = Tests;
 			sourceTree = "<group>";
 		};
 		0694B2EE295B2E0A406247AC /* ViewModels */ = {
@@ -587,10 +625,19 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		4B789673EBCAA4E188583135 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				5B36A6E676E49FF5251075A3 /* AlamofireNetworkingManagerTests.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
 		50C33D9429F20B5A9A014919 /* Core */ = {
 			isa = PBXGroup;
 			children = (
 				7BE0441C5691A11794D5E8FE /* Sources */,
+				0390F904E1F037F08DFFDA45 /* Tests */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -722,8 +769,8 @@
 			children = (
 				323C6862B40AB698B53CB061 /* CreateReceiptFormView.swift */,
 				C1A02CCA8D41FCB58C3FA231 /* CreateReceiptView.swift */,
+				FD6502D342639F99F469DFFD /* MonthPickerView.swift */,
 				90530BC5F3252C5B62824160 /* ReceiptListView.swift */,
-				F525AD4D2D8FFB1B00CE4D3E /* MonthPickerView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -885,8 +932,8 @@
 		D23909B2AAE71BB9BD1D38C8 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				F528F7B22D8D7B17001EB483 /* MaintenanceView.swift */,
 				B942DFCDEF3AA88E2818E77E /* ContentView.swift */,
+				E9BE8A3EFF47B1A47D5DAA28 /* MaintenanceView.swift */,
 				0434389C67FC072619AA1FD0 /* SplashScreenView.swift */,
 				83AF01502CD02A7884EB6964 /* ToMyongJi_iOSApp.swift */,
 			);
@@ -898,6 +945,7 @@
 			children = (
 				04FFD79F3BD12493D40B9FA8 /* App.framework */,
 				4E6E6FA698BFDCA48CBC1A58 /* Core.framework */,
+				44ED7F91622732D9D7BB4A23 /* CoreTests.xctest */,
 				79E57EC36E48D72F62A7553D /* Feature.framework */,
 				9E0208492746ACB4D68A285C /* ToMyongJi_iOS.app */,
 				26515D53170FF30DD2863442 /* UI.framework */,
@@ -918,6 +966,7 @@
 			children = (
 				203AC5F0800E4EF75677AD65 /* App-Info.plist */,
 				76B419841B30D48E82E11143 /* Core-Info.plist */,
+				7B8F3A79294BC6BFD0F9E625 /* CoreTests-Info.plist */,
 				F94FA58B29F48CF265E924FE /* Feature-Info.plist */,
 				F8C703DC525E6154C8D0364C /* UI-Info.plist */,
 			);
@@ -1070,6 +1119,25 @@
 			productReference = 04FFD79F3BD12493D40B9FA8 /* App.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		6931F4368E771245D2A9E17D /* CoreTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2C31BF2EC6ED7E2E6E582383 /* Build configuration list for PBXNativeTarget "CoreTests" */;
+			buildPhases = (
+				0F45EA8482796284D78CEE53 /* Sources */,
+				F5A8AC4A2ADA07071B7D918D /* Resources */,
+				C06803E636F352DF0B729708 /* Embed Frameworks */,
+				4D4ED60ED788A95753FBFA84 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EAE2659F444FEA4AD9B511FE /* PBXTargetDependency */,
+			);
+			name = CoreTests;
+			productName = CoreTests;
+			productReference = 44ED7F91622732D9D7BB4A23 /* CoreTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		8BFBC7B529ACBD5B074DBED3 /* Core */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 27C1935D2BF7FD46E0524ADE /* Build configuration list for PBXNativeTarget "Core" */;
@@ -1160,6 +1228,7 @@
 				0B89B129FD7D90DE26960F7E /* Feature */,
 				8BFBC7B529ACBD5B074DBED3 /* Core */,
 				DCFC6BD53C5504F6AF0FDBDD /* UI */,
+				6931F4368E771245D2A9E17D /* CoreTests */,
 			);
 		};
 /* End PBXProject section */
@@ -1208,6 +1277,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F5A8AC4A2ADA07071B7D918D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -1222,6 +1298,14 @@
 				B1A81BC8B44860D29B1EFC4B /* GradientButton.swift in Sources */,
 				2C4C2FD804A38F1E815CBDE7 /* Color+Extensions.swift in Sources */,
 				DADCF523967B11CF4130BBB5 /* View+Extensions.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0F45EA8482796284D78CEE53 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D3A04BC842373FF7FE3FCC12 /* AlamofireNetworkingManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1271,14 +1355,13 @@
 				18F54CC16B367014FF4733A2 /* ReceiptViewModel.swift in Sources */,
 				FDB8C991ABD9B952EBC45B45 /* CreateReceiptFormView.swift in Sources */,
 				FDDF8D2E806619E818A6AECA /* CreateReceiptView.swift in Sources */,
+				439B1E0DDAC7DDCFD4661D45 /* MonthPickerView.swift in Sources */,
 				52599826619CE750A8DBC1DA /* ReceiptListView.swift in Sources */,
-				F528F7B32D8D7B17001EB483 /* MaintenanceView.swift in Sources */,
 				5A51C8F20F9AF46401549F4B /* AgreementType.swift in Sources */,
 				825DED37FBF7F130E06F181E /* SignUp.swift in Sources */,
 				15AC8737B62235755ED0D214 /* SignUpEndpoint.swift in Sources */,
 				ED5F6DFCD9689DA389D955CC /* SignUpViewModel.swift in Sources */,
 				A7CF8A2AE856A1B6E83DF2ED /* InputClubAuthenticationView.swift in Sources */,
-				F525AD4E2D8FFB1B00CE4D3E /* MonthPickerView.swift in Sources */,
 				50AD9E71978D1F56DB597DF9 /* InputEmailView.swift in Sources */,
 				A8FFD092A2FE7D3EDECF345B /* InputIDView.swift in Sources */,
 				11BB9F7835F838BBCB96EEAB /* InputPasswordView.swift in Sources */,
@@ -1295,9 +1378,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				32C320C79D21092DA1B8D2A4 /* ContentView.swift in Sources */,
+				3BE7E7D4A7BD5BA5658F06FD /* MaintenanceView.swift in Sources */,
 				2E19C451AACCC1767B2BB932 /* SplashScreenView.swift in Sources */,
 				354DE0104D5E485A68E084AE /* ToMyongJi_iOSApp.swift in Sources */,
-				F528F7B42D8D7B17001EB483 /* MaintenanceView.swift in Sources */,
 				0837F86D652FB69BF24DDDFA /* TuistAssets+ToMyongJiIOS.swift in Sources */,
 				AC76142CA39EADAEA1CC6C91 /* TuistBundle+ToMyongJiIOS.swift in Sources */,
 				7237D0EF284D9A7E02303118 /* TuistFonts+ToMyongJiIOS.swift in Sources */,
@@ -1309,6 +1392,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E3A01931922BCCC9957CC456 /* ContentView.swift in Sources */,
+				620DD781A254D52968A410EA /* MaintenanceView.swift in Sources */,
 				E880FCCB5766E71E0FB4E8E0 /* SplashScreenView.swift in Sources */,
 				D26501B69E5A7332ECA7A9A7 /* ToMyongJi_iOSApp.swift in Sources */,
 			);
@@ -1370,6 +1454,12 @@
 			target = 8BFBC7B529ACBD5B074DBED3 /* Core */;
 			targetProxy = B334EDE831B8E8E1683EE916 /* PBXContainerItemProxy */;
 		};
+		EAE2659F444FEA4AD9B511FE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Core;
+			target = 8BFBC7B529ACBD5B074DBED3 /* Core */;
+			targetProxy = 13215CEB660F1A2F2B15FAC9 /* PBXContainerItemProxy */;
+		};
 		FED2FCC18075EF59EF8F3B8B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Core;
@@ -1384,17 +1474,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = FN67GXC5GH;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = App/Resources/Info.plist;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.education";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tomyongji.ios;
 				PRODUCT_NAME = ToMyongJi_iOS;
 				SDKROOT = iphoneos;
@@ -1414,17 +1499,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = FN67GXC5GH;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = App/Resources/Info.plist;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.education";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tomyongji.ios;
 				PRODUCT_NAME = ToMyongJi_iOS;
 				SDKROOT = iphoneos;
@@ -1451,7 +1531,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Derived/InfoPlists/App-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1461,6 +1540,7 @@
 				PRODUCT_NAME = App;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1468,7 +1548,7 @@
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1485,7 +1565,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Derived/InfoPlists/UI-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1495,13 +1574,14 @@
 				PRODUCT_NAME = UI;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1518,7 +1598,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Derived/InfoPlists/Feature-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1528,13 +1607,14 @@
 				PRODUCT_NAME = Feature;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1551,7 +1631,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Derived/InfoPlists/App-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1561,15 +1640,65 @@
 				PRODUCT_NAME = App;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		BCA8ECC5CA31E56F8AAB05CC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = "Derived/InfoPlists/CoreTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.tomyongji.coreTests;
+				PRODUCT_NAME = CoreTests;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_COMPILATION_MODE = singlefile;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		C0B0B17E5C5CD9F705C0F2E8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = "Derived/InfoPlists/CoreTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.tomyongji.coreTests;
+				PRODUCT_NAME = CoreTests;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};
@@ -1584,7 +1713,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Derived/InfoPlists/Feature-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1594,6 +1722,7 @@
 				PRODUCT_NAME = Feature;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1601,7 +1730,7 @@
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1618,7 +1747,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Derived/InfoPlists/Core-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1628,6 +1756,7 @@
 				PRODUCT_NAME = Core;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1635,7 +1764,7 @@
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1705,7 +1834,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Derived/InfoPlists/UI-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1715,6 +1843,7 @@
 				PRODUCT_NAME = UI;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1722,7 +1851,7 @@
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1798,7 +1927,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Derived/InfoPlists/Core-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1808,13 +1936,14 @@
 				PRODUCT_NAME = Core;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1828,6 +1957,15 @@
 			buildConfigurations = (
 				DCAB14937E321F3CB52A001E /* Debug */,
 				FF4611586E302DE985683FC3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2C31BF2EC6ED7E2E6E582383 /* Build configuration list for PBXNativeTarget "CoreTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BCA8ECC5CA31E56F8AAB05CC /* Debug */,
+				C0B0B17E5C5CD9F705C0F2E8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ToMyongJi.xcodeproj/xcshareddata/xcschemes/Core.xcscheme
+++ b/ToMyongJi.xcodeproj/xcshareddata/xcschemes/Core.xcscheme
@@ -26,9 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      disableMainThreadChecker = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6931F4368E771245D2A9E17D"
+               BuildableName = "CoreTests.xctest"
+               BlueprintName = "CoreTests"
+               ReferencedContainer = "container:ToMyongJi.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #91 

### 📝작업 내용

> Core-Network 테스트 코드를 위한 tuist Project.swift 세팅
- Project.swift의 .target 세팅
- Core/Tests/Network 세팅

### 🔨테스트 결과 > 스크린샷 (선택)

<img width="340" alt="image" src="https://github.com/user-attachments/assets/e61f06cb-9019-4f43-9c51-436b75cc04af" />


