### PR TITLE
Test: Core module의 AlamofireNetworkingManagerTests

### DIFF
--- a/Core/Tests/Network/AlamofireNetworkingManagerTests.swift
+++ b/Core/Tests/Network/AlamofireNetworkingManagerTests.swift
@@ -12,5 +12,111 @@ import Combine
 @testable import Core
 
 final class AlamofireNetworkingManagerTests: XCTestCase {
+    var sut: AlamofireNetworkingManager!
+    var cancellables: Set<AnyCancellable>!
     
+    override func setUp() {
+        super.setUp()
+        sut = AlamofireNetworkingManager.shared
+        cancellables = []
+    }
+    
+    override func tearDown() {
+        sut = nil
+        cancellables = nil
+        super.tearDown()
+    }
+    
+    // MARK: - API 호출 테스트
+    
+    func test_WhenAPICallSucceeds_ReturnsData() {
+        let expectation = XCTestExpectation(description: "API 호출 성공")
+        let endpoint = TestEndpoint.getTest
+        
+        sut.run(endpoint, type: TestResponse.self)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    XCTFail("API call failed: \(error)")
+                }
+                expectation.fulfill()
+            } receiveValue: { response in
+                XCTAssertNotNil(response)
+            }
+            .store(in: &cancellables)
+        
+        wait(for: [expectation], timeout: 5.0)
+    }
+    
+    func test_WhenAPICallFails_ReturnsError() {
+        let expectation = XCTestExpectation(description: "API 호출 실패")
+        let endpoint = TestEndpoint.invalidURL
+        
+        sut.run(endpoint, type: TestResponse.self)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    XCTFail("API call succeeded but should fail")
+                case .failure(let error):
+                    XCTAssertNotNil(error)
+                }
+                expectation.fulfill()
+            } receiveValue: { _ in
+                XCTFail("Data returned but should fail")
+            }
+            .store(in: &cancellables)
+        
+        wait(for: [expectation], timeout: 5.0)
+    }
+}
+
+// MARK: - 테스트
+
+extension AlamofireNetworkingManagerTests {
+    enum TestEndpoint: Endpoint {
+        case getTest
+        case invalidURL
+        
+        var path: String {
+            switch self {
+            case .getTest:
+                return "/api/club"
+            case .invalidURL:
+                return "/invalidURL"
+            }
+        }
+        
+        var headers: [String : String] {
+            ["Content-Type": "application/json"]
+        }
+        
+        var parameters: [String : Any] {
+            [:]
+        }
+        
+        var query: [String : String] {
+            [:]
+        }
+        
+        var method: HTTPMethod {
+            .get
+        }
+        
+        public var encoding: ParameterEncoding {
+            URLEncoding.default
+        }
+    }
+    
+    struct TestResponse: Codable {
+        let statusCode: Int
+        let statusMessage: String
+        let data: [TestResponseData]
+    }
+    
+    struct TestResponseData: Codable {
+        let studentClubId: Int
+        let studentClubName: String
+    }
 }

--- a/Project.swift
+++ b/Project.swift
@@ -9,7 +9,7 @@ let project = Project(
     targets: [
         .target(
             name: "ToMyongJi-iOS",
-            destinations: [.iPhone, .iPad],
+            destinations: [.iPhone],
             product: .app,
             bundleId: "com.tomyongji.ios",
             infoPlist: .file(path: "App/Resources/Info.plist"),
@@ -26,7 +26,7 @@ let project = Project(
         ),
         .target(
             name: "App",
-            destinations: [.iPhone, .iPad],
+            destinations: [.iPhone],
             product: .framework,
             bundleId: "com.tomyongji.app",
             infoPlist: .extendingDefault(with: [:]),
@@ -39,7 +39,7 @@ let project = Project(
         ),
         .target(
             name: "Feature",
-            destinations: [.iPhone, .iPad],
+            destinations: [.iPhone],
             product: .framework,
             bundleId: "com.tomyongji.feature",
             infoPlist: .extendingDefault(with: [:]),
@@ -51,7 +51,7 @@ let project = Project(
         ),
         .target(
             name: "Core",
-            destinations: [.iPhone, .iPad],
+            destinations: [.iPhone],
             product: .framework,
             bundleId: "com.tomyongji.core",
             infoPlist: .extendingDefault(with: [:]),
@@ -62,7 +62,7 @@ let project = Project(
         ),
         .target(
             name: "UI",
-            destinations: [.iPhone, .iPad],
+            destinations: [.iPhone],
             product: .framework,
             bundleId: "com.tomyongji.ui",
             infoPlist: .extendingDefault(with: [:]),
@@ -74,7 +74,7 @@ let project = Project(
         ),
         .target(
             name: "CoreTests",
-            destinations: [.iPhone, .iPad],
+            destinations: [.iPhone],
             product: .unitTests,
             bundleId: "com.tomyongji.coreTests",
             infoPlist: .extendingDefault(with: [:]),

--- a/ToMyongJi.xcodeproj/project.pbxproj
+++ b/ToMyongJi.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1206,6 +1206,8 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				ORGANIZATIONNAME = ToMyongJi;
+				TargetAttributes = {
+				};
 			};
 			buildConfigurationList = D83261D0E22D58AD5DBEE3E0 /* Build configuration list for PBXProject "ToMyongJi" */;
 			compatibilityVersion = "Xcode 14.0";
@@ -1483,7 +1485,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.tomyongji.ios;
 				PRODUCT_NAME = ToMyongJi_iOS;
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1508,11 +1509,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.tomyongji.ios;
 				PRODUCT_NAME = ToMyongJi_iOS;
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+					"$(inherited)",
+					DEBUG,
+				);
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1540,11 +1543,13 @@
 				PRODUCT_NAME = App;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+					"$(inherited)",
+					DEBUG,
+				);
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1574,7 +1579,6 @@
 				PRODUCT_NAME = UI;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1607,7 +1611,6 @@
 				PRODUCT_NAME = Feature;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1640,7 +1643,6 @@
 				PRODUCT_NAME = App;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1666,11 +1668,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.tomyongji.coreTests;
 				PRODUCT_NAME = CoreTests;
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+					"$(inherited)",
+					DEBUG,
+				);
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1691,7 +1695,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.tomyongji.coreTests;
 				PRODUCT_NAME = CoreTests;
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1722,11 +1725,13 @@
 				PRODUCT_NAME = Feature;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+					"$(inherited)",
+					DEBUG,
+				);
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1756,11 +1761,13 @@
 				PRODUCT_NAME = Core;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+					"$(inherited)",
+					DEBUG,
+				);
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1843,11 +1850,13 @@
 				PRODUCT_NAME = UI;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+					"$(inherited)",
+					DEBUG,
+				);
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1936,7 +1945,6 @@
 				PRODUCT_NAME = Core;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #91 

### 📝작업 내용

> Core module의 AlamofireNetworkingManagerTests
- XCTest 프레임워크를 사용한 테스트코드 작성
- AlamofireNetworkingManagerTests 테스트코드 클래스 구조 구현
- AlamofireNetworkingManagerTests API 호출 성공/실패 테스트 케이스 구현
- 이번 테스트코드 구현을 통해 네트워크 레이어의 안정성에 대해 확보

### 🔨테스트 결과 > 스크린샷 (선택)

<img width="1440" alt="스크린샷 2025-03-26 오후 4 59 12" src="https://github.com/user-attachments/assets/53faa790-5586-4084-8561-94d4978a02af" />


