### PR TITLE
Test: setUp -> setUpWithError, tearDown -> tearDownWithError

### DIFF
--- a/Core/Tests/Network/AlamofireNetworkingManagerTests.swift
+++ b/Core/Tests/Network/AlamofireNetworkingManagerTests.swift
@@ -15,16 +15,16 @@ final class AlamofireNetworkingManagerTests: XCTestCase {
     var sut: AlamofireNetworkingManager!
     var cancellables: Set<AnyCancellable>!
     
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         sut = AlamofireNetworkingManager.shared
         cancellables = []
     }
     
-    override func tearDown() {
+    override func tearDownWithError() throws {
+        try super.tearDown()
         sut = nil
         cancellables = nil
-        super.tearDown()
     }
     
     // MARK: - API 호출 테스트


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #91 

### 📝작업 내용

> setUp -> setUpWithError, tearDown -> tearDownWithError
- 에러 가능성이 있는 네트워크 요청 테스트를 위해 error를 던질 수 있게 수정

### 🔨테스트 결과 > 스크린샷 (선택)

<img width="1440" alt="스크린샷 2025-03-27 오후 2 14 15" src="https://github.com/user-attachments/assets/b433afa2-aa55-48b0-b6e9-7374e3516819" />


