### PR TITLE
Test: AuthenticationManager 토큰 관리 테스트

### DIFF
--- a/Core/Sources/Authentication/AuthenticationManager.swift
+++ b/Core/Sources/Authentication/AuthenticationManager.swift
@@ -83,6 +83,7 @@ public class AuthenticationManager {
         userRole = nil
         userId = nil
         userLoginId = nil
+        tokenExpiration = nil
         
         tokenExpirationTimer?.invalidate()
         tokenExpirationTimer = nil
@@ -101,17 +102,25 @@ public class AuthenticationManager {
     }
     
     // 토큰 만료 처리
-    private func handleTokenExpiration() {
+    public func handleTokenExpiration() {
         clearAuthentication()
         NotificationCenter.default.post(name: .tokenExpired, object: nil)
     }
     
     // 토큰 만료 여부 확인
     public func isTokenValid() -> Bool {
-        guard let expirationDate = UserDefaults.standard.object(forKey: tokenExpirationKey) as? Date else {
+        guard let expirationDate = tokenExpiration,
+              let accessToken = accessToken,
+              !accessToken.isEmpty else {
+            handleTokenExpiration()
             return false
         }
-        return expirationDate > Date()
+        
+        let isValid = expirationDate > Date()
+        if !isValid {
+            handleTokenExpiration()
+        }
+        return isValid
     }
 }
 

--- a/Core/Tests/Authentication/AuthenticationManagerTests.swift
+++ b/Core/Tests/Authentication/AuthenticationManagerTests.swift
@@ -1,0 +1,111 @@
+//
+//  AuthenticationManagerTests.swift
+//  ToMyongJi-iOS
+//
+//  Created by JunKyu Lee on 3/27/25.
+//  Copyright © 2025 ToMyongJi. All rights reserved.
+//
+
+import XCTest
+@testable import Core
+
+final class AuthenticationManagerTests: XCTestCase {
+    var sut: AuthenticationManager!
+    
+    override func setUp() {
+        super.setUp()
+        sut = AuthenticationManager.shared
+    }
+    
+    override func tearDown() {
+        sut.clearAuthentication()
+        super.tearDown()
+        sut = nil
+    }
+    
+    // MARK: - 사용자 정보를 저장 테스트
+    
+    func test_WhenSaveAuthentication_ThenUserInfoIsSaved() {
+        // given
+        let testAccessToken: String = "test-access-token"
+        let testDecodedToken: DecodedToken = DecodedToken(
+            auth: "test-auth",
+            exp: Int(Date().addingTimeInterval(3600).timeIntervalSince1970),
+            id: 1,
+            sub: "test-sub"
+        )
+        
+        // when
+        sut.saveAuthentication(accessToken: testAccessToken, decodedToken: testDecodedToken)
+        
+        // then
+        XCTAssertTrue(sut.isAuthenticated)
+        XCTAssertEqual(sut.accessToken, testAccessToken)
+        XCTAssertEqual(sut.userRole, testDecodedToken.auth)
+        XCTAssertEqual(sut.userId, testDecodedToken.id)
+        XCTAssertEqual(sut.userLoginId, testDecodedToken.sub)
+        XCTAssertEqual(sut.tokenExpiration, Date(timeIntervalSince1970: TimeInterval(testDecodedToken.exp)))
+    }
+    
+    // MARK: - 사용자 정보를 삭제 테스트
+    
+    func test_WhenClearAuthentication_ThenUserInfoIsCleared() {
+        // given
+        let testAccessToken: String = "test-access-token"
+        let testDecodedToken: DecodedToken = DecodedToken(
+            auth: "test-auth",
+            exp: Int(Date().addingTimeInterval(3600).timeIntervalSince1970),
+            id: 1,
+            sub: "test-sub"
+        )
+        sut.saveAuthentication(accessToken: testAccessToken, decodedToken: testDecodedToken)
+        
+        //when
+        sut.clearAuthentication()
+        
+        // then
+        XCTAssertFalse(sut.isAuthenticated)
+        XCTAssertNil(sut.accessToken)
+        XCTAssertNil(sut.userRole)
+        XCTAssertNil(sut.userId)
+        XCTAssertNil(sut.userLoginId)
+        XCTAssertNil(sut.tokenExpiration)
+    }
+    
+    // MARK: - 토큰 만료 테스트
+    
+    func test_WhenTokenIsExpired_ThenAuthenticationIsCleared() {
+        // Given
+        let expectation = XCTestExpectation(description: "토큰 만료 알림")
+        let testAccessToken: String = "test-access-token"
+        let testDecodedToken: DecodedToken = DecodedToken(
+            auth: "test-auth",
+            exp: Int(Date().addingTimeInterval(-3600).timeIntervalSince1970), // 1시간 전 만료
+            id: 1,
+            sub: "test-sub"
+        )
+        
+        // 토큰 만료 알림 관찰
+        NotificationCenter.default.addObserver(
+            forName: .tokenExpired,
+            object: nil,
+            queue: nil
+        ) { _ in
+            expectation.fulfill()
+        }
+        
+        // When
+        sut.saveAuthentication(accessToken: testAccessToken, decodedToken: testDecodedToken)
+        
+        // Then
+        XCTAssertFalse(sut.isTokenValid())
+        XCTAssertFalse(sut.isAuthenticated)
+        XCTAssertNil(sut.accessToken)
+        XCTAssertNil(sut.userRole)
+        XCTAssertNil(sut.userId)
+        XCTAssertNil(sut.userLoginId)
+        XCTAssertNil(sut.tokenExpiration)
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+}

--- a/ToMyongJi.xcodeproj/project.pbxproj
+++ b/ToMyongJi.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -337,6 +337,20 @@
 		FE47F37DC5E4D08AA9C53989 /* SelectCollegesAndClubsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectCollegesAndClubsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		F51DD74C2D95195A00249FF0 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				AuthenticationManagerTests.swift,
+			);
+			target = DE41B31E49415D6F9F1E4580 /* ToMyongJi-iOS */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		F51DD7482D95194C00249FF0 /* Authentication */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (F51DD74C2D95195A00249FF0 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Authentication; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		4D4ED60ED788A95753FBFA84 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -413,6 +427,7 @@
 		0390F904E1F037F08DFFDA45 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				F51DD7482D95194C00249FF0 /* Authentication */,
 				4B789673EBCAA4E188583135 /* Network */,
 			);
 			path = Tests;
@@ -1133,6 +1148,9 @@
 			dependencies = (
 				EAE2659F444FEA4AD9B511FE /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				F51DD7482D95194C00249FF0 /* Authentication */,
+			);
 			name = CoreTests;
 			productName = CoreTests;
 			productReference = 44ED7F91622732D9D7BB4A23 /* CoreTests.xctest */;
@@ -1206,8 +1224,6 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				ORGANIZATIONNAME = ToMyongJi;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = D83261D0E22D58AD5DBEE3E0 /* Build configuration list for PBXProject "ToMyongJi" */;
 			compatibilityVersion = "Xcode 14.0";
@@ -1512,10 +1528,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-					"$(inherited)",
-					DEBUG,
-				);
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1546,10 +1559,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-					"$(inherited)",
-					DEBUG,
-				);
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1671,10 +1681,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-					"$(inherited)",
-					DEBUG,
-				);
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1728,10 +1735,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-					"$(inherited)",
-					DEBUG,
-				);
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1764,10 +1768,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-					"$(inherited)",
-					DEBUG,
-				);
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1853,10 +1854,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-					"$(inherited)",
-					DEBUG,
-				);
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #91 

### 📝작업 내용

> AuthenticationManager 토큰 관리 테스트
- 로그인 성공시 토큰, 사용자 정보 저장 테스트
- 로그아웃시 토큰, 사용자 정보 삭제 테스트
- 토큰 만료시 로그아웃 처리 및 사용자 정보 삭제 테스트

### 🔨테스트 결과 > 스크린샷 (선택)

<img width="1440" alt="스크린샷 2025-03-29 오후 3 20 33" src="https://github.com/user-attachments/assets/92222a63-3a2b-4513-88ab-98af45bae9d4" />

