### PR TITLE
Test: url 생성을 담당하는 EndpointEnum 테스트 코드 구현

### DIFF
--- a/Core/Tests/Endpoint/EndpointEnumTests.swift
+++ b/Core/Tests/Endpoint/EndpointEnumTests.swift
@@ -1,0 +1,63 @@
+//
+//  EndpointEnumTests.swift
+//  ToMyongJi-iOS
+//
+//  Created by JunKyu Lee on 3/31/25.
+//  Copyright © 2025 ToMyongJi. All rights reserved.
+//
+
+import XCTest
+import Alamofire
+@testable import Core
+
+final class EndpointEnumTests: XCTestCase {
+    
+    // 테스트를 위한 Mcock Endpoint
+    struct MockEndpoint: Endpoint {
+        var path: String
+        var headers: [String: String]
+        var query: [String: String]
+        var parameters: [String: Any]
+        var method: HTTPMethod
+        var encoding: ParameterEncoding
+        
+        init(path: String, headers: [String: String], query: [String: String], parameters: [String: Any], method: HTTPMethod, encoding: ParameterEncoding) {
+            self.path = path
+            self.headers = headers
+            self.query = query
+            self.parameters = parameters
+            self.method = method
+            self.encoding = encoding
+        }
+    }
+    
+    // MARK: - 쿼리가 있을 때 URL 생성 테스트
+    func test_WhenCreateURLWithQuery_ThenURLIsCorrect() {
+        // given
+        let mockEndpoint: MockEndpoint = MockEndpoint(path: "/api/test/endpointEnum", headers: [:], query: ["key": "value"], parameters: [:], method: .get, encoding: URLEncoding.default)
+        
+        // when
+        let url: URL = mockEndpoint.url
+        
+        // then
+        XCTAssertEqual(url.scheme, "https")
+        XCTAssertEqual(url.host, "api.tomyongji.com")
+        XCTAssertEqual(url.path, "/api/test/endpointEnum")
+        XCTAssertEqual(url.query, "key=value")
+    }
+    
+    // MARK: - 쿼리가 없을 때 URL 생성 테스트
+    func test_WhenCreateURLWithoutQuery_ThenURLIsCorrect() {
+        // given
+        let mockEndpoint: MockEndpoint = MockEndpoint(path: "/api/test/endpointEnum", headers: [:], query: [:], parameters: [:], method: .get, encoding: URLEncoding.default)
+        
+        // when
+        let url: URL = mockEndpoint.url
+        
+        // then
+        XCTAssertEqual(url.scheme, "https")
+        XCTAssertEqual(url.host, "api.tomyongji.com")
+        XCTAssertEqual(url.path, "/api/test/endpointEnum")
+        XCTAssertNil(url.query)
+    }
+}

--- a/ToMyongJi.xcodeproj/project.pbxproj
+++ b/ToMyongJi.xcodeproj/project.pbxproj
@@ -345,10 +345,18 @@
 			);
 			target = DE41B31E49415D6F9F1E4580 /* ToMyongJi-iOS */;
 		};
+		F5D1CB402D9AA91E00B4A5D5 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				EndpointEnumTests.swift,
+			);
+			target = DE41B31E49415D6F9F1E4580 /* ToMyongJi-iOS */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		F51DD7482D95194C00249FF0 /* Authentication */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (F51DD74C2D95195A00249FF0 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Authentication; sourceTree = "<group>"; };
+		F5D1CB3C2D9AA90E00B4A5D5 /* Endpoint */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (F5D1CB402D9AA91E00B4A5D5 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Endpoint; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -427,6 +435,7 @@
 		0390F904E1F037F08DFFDA45 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				F5D1CB3C2D9AA90E00B4A5D5 /* Endpoint */,
 				F51DD7482D95194C00249FF0 /* Authentication */,
 				4B789673EBCAA4E188583135 /* Network */,
 			);
@@ -1150,6 +1159,7 @@
 			);
 			fileSystemSynchronizedGroups = (
 				F51DD7482D95194C00249FF0 /* Authentication */,
+				F5D1CB3C2D9AA90E00B4A5D5 /* Endpoint */,
 			);
 			name = CoreTests;
 			productName = CoreTests;


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #91 

### 📝작업 내용

> url 생성을 담당하는 EndpointEnum 테스트 코드 구현
- mockEndpoint를 사용해 쿼리 유무에 따른 url 생성 테스트 구현

### 🔨테스트 결과 > 스크린샷 (선택)

![스크린샷 2025-03-31 오후 10 49 13(2)](https://github.com/user-attachments/assets/ab0be33a-0964-42c5-ba19-96e21cf016fe)

