### PR TITLE
Test: LoginViewModel 테스트 코드 비동기 통신 수정

### DIFF
--- a/Derived/InfoPlists/FeatureTests-Info.plist
+++ b/Derived/InfoPlists/FeatureTests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Feature/Sources/Login/ViewModels/LoginViewModel.swift
+++ b/Feature/Sources/Login/ViewModels/LoginViewModel.swift
@@ -20,10 +20,20 @@ class LoginViewModel {
     var showAlert: Bool = false
     var isSuccess: Bool = false
     
-    public let networkingManager = AlamofireNetworkingManager.shared
-    public let tokenService = TokenService.shared
-    public let authManager = AuthenticationManager.shared
-    public var cancellables = Set<AnyCancellable>()
+    var networkingManager: AlamofireNetworkingManager
+    var tokenService: TokenService
+    var authManager: AuthenticationManager
+    var cancellables = Set<AnyCancellable>()
+    
+    init(
+        networkingManager: AlamofireNetworkingManager = .shared,
+        tokenService: TokenService = .shared,
+        authManager: AuthenticationManager = .shared
+    ) {
+        self.networkingManager = networkingManager
+        self.tokenService = tokenService
+        self.authManager = authManager
+    }
     
     func login() {
         isLoading = true
@@ -42,7 +52,7 @@ class LoginViewModel {
                     self.alertMessage = "아이디와 비밀번호를 확인해주세요."
                     self.showAlert = true
                     self.isSuccess = false
-                default:
+                case .finished:
                     break
                 }
             } receiveValue: { [weak self] loginResponse in
@@ -53,7 +63,6 @@ class LoginViewModel {
                         accessToken: loginResponse.data.accessToken,
                         decodedToken: decodedToken
                     )
-                    print(decodedToken)
                     self.alertMessage = "로그인에 성공했습니다."
                     self.showAlert = true
                     self.isSuccess = true
@@ -61,6 +70,11 @@ class LoginViewModel {
                     // 로그인 성공 후 입력 필드 초기화
                     self.userId = ""
                     self.password = ""
+                } else {
+                    self.error = NSError(domain: "TokenError", code: -1, userInfo: [NSLocalizedDescriptionKey: "토큰 디코딩 실패"])
+                    self.alertMessage = "로그인 처리 중 오류가 발생했습니다."
+                    self.showAlert = true
+                    self.isSuccess = false
                 }
             }
             .store(in: &cancellables)

--- a/Feature/Tests/Login/LoginViewModelTests.swift
+++ b/Feature/Tests/Login/LoginViewModelTests.swift
@@ -24,19 +24,42 @@ final class LoginViewModelTests: XCTestCase {
     
     // MARK: - 로그인 테스트
     
-    func test_WhenLoginSuccess_ThenSaveToken() {
+    func test_WhenLoginSuccess_ThenSaveToken() throws {
         // given
-        let testUserId: String = "tomyongji"
-        let testPassword: String = "Tomyongji123!"
+        sut.userId = "tomyongji"
+        sut.password = "Tomyongji123!"
+        
+        let expectation = XCTestExpectation(description: "로그인에 성공했습니다.")
         
         // when
         sut.login()
         
         // then
-        XCTAssertTrue(sut.authManager.isAuthenticated)
-        XCTAssertNotNil(sut.authManager.userRole)
-        XCTAssertNotNil(sut.authManager.userId)
-        XCTAssertNotNil(sut.authManager.userLoginId)
-        XCTAssertNotNil(sut.authManager.accessToken)
+        // 비동기 작업이 완료될 때까지 대기
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            // 1. 로딩 상태 확인
+            XCTAssertFalse(self.sut.isLoading)  // 로그인 완료 후 false여야 함
+            
+            // 2. 에러 상태 확인
+            XCTAssertNil(self.sut.error)
+            XCTAssertTrue(self.sut.showAlert)
+            XCTAssertEqual(self.sut.alertMessage, "로그인에 성공했습니다.")
+            XCTAssertTrue(self.sut.isSuccess)
+            
+            // 3. 인증 상태 확인
+            XCTAssertTrue(self.sut.authManager.isAuthenticated)
+            XCTAssertNotNil(self.sut.authManager.userRole)
+            XCTAssertNotNil(self.sut.authManager.userId)
+            XCTAssertNotNil(self.sut.authManager.userLoginId)
+            XCTAssertNotNil(self.sut.authManager.accessToken)
+            
+            // 4. 입력 필드 초기화 확인
+            XCTAssertEqual(self.sut.userId, "")
+            XCTAssertEqual(self.sut.password, "")
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
     }
 }

--- a/Project.swift
+++ b/Project.swift
@@ -82,6 +82,17 @@ let project = Project(
             dependencies: [
                 .target(name: "Core")
             ]
+        ),
+        .target(
+            name: "FeatureTests",
+            destinations: [.iPhone],
+            product: .unitTests,
+            bundleId: "com.tomyongji.featureTests",
+            infoPlist: .extendingDefault(with: [:]),
+            sources: ["Feature/Tests/**"],
+            dependencies: [
+                .target(name: "Feature")
+            ]
         )
     ]
 )

--- a/ToMyongJi.xcodeproj/project.pbxproj
+++ b/ToMyongJi.xcodeproj/project.pbxproj
@@ -3,13 +3,15 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0227BAF3C7528EE3AB22DCE4 /* EndpointEnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572B173E515CAD1851B4D115 /* EndpointEnumTests.swift */; };
 		02410C6EAA0E4D6CAD4B5CA5 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B2138AAA12DA57CD37C2B7 /* LoginView.swift */; };
 		04600D8F7F338E9FAA8A8DF4 /* UI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26515D53170FF30DD2863442 /* UI.framework */; };
 		0837F86D652FB69BF24DDDFA /* TuistAssets+ToMyongJiIOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4007B3111D84601BEF7F198F /* TuistAssets+ToMyongJiIOS.swift */; };
+		0AF567CE918C4EF6271CFF3A /* AuthenticationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB662513BB59FD2768462EAE /* AuthenticationManagerTests.swift */; };
 		11BB9F7835F838BBCB96EEAB /* InputPasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29452F0FF0CF6C327447CFB0 /* InputPasswordView.swift */; };
 		126E493559D72CC2C15F357A /* Receipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7484C47FE8D12F7E95F24DC6 /* Receipt.swift */; };
 		15AC8737B62235755ED0D214 /* SignUpEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E04969DDCC77A17FF2EE0EBC /* SignUpEndpoint.swift */; };
@@ -41,6 +43,7 @@
 		439B1E0DDAC7DDCFD4661D45 /* MonthPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6502D342639F99F469DFFD /* MonthPickerView.swift */; };
 		4717D3205BEBECFF15468204 /* SignUpAgreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131942CF256661618987D380 /* SignUpAgreeView.swift */; };
 		4768A3DC7C1892F0FA9B49CF /* GmarketSansBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7F4EE414B972F985522AAC3F /* GmarketSansBold.otf */; };
+		4F979A0F9C7493F874BBBA2F /* LoginViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 432A6A47ADFAEE9A3AB423B9 /* LoginViewModelTests.swift */; };
 		50AD9E71978D1F56DB597DF9 /* InputEmailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B5171995BA262DFC700D09 /* InputEmailView.swift */; };
 		52599826619CE750A8DBC1DA /* ReceiptListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90530BC5F3252C5B62824160 /* ReceiptListView.swift */; };
 		5A3A1DED3CE4A541DC09D803 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2789C497FD47EE83841F5912 /* Assets.xcassets */; };
@@ -56,6 +59,7 @@
 		6F9CCE4D259A04BC0483DC12 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E04B0F3168EF17B2642BF2 /* LoginViewModel.swift */; };
 		7136F22987457DAB7B39401D /* CustomTF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DBFAD8D70C6358B8A1B957E /* CustomTF.swift */; };
 		7237D0EF284D9A7E02303118 /* TuistFonts+ToMyongJiIOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDAE4F0006E0A0A87059FAD /* TuistFonts+ToMyongJiIOS.swift */; };
+		78BCFD39761E82405618839B /* Feature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 79E57EC36E48D72F62A7553D /* Feature.framework */; };
 		7ADB34B632EF51F204195FBB /* LoginEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 337287252058E4826C70E727 /* LoginEndpoint.swift */; };
 		7BC1996636A01AA917C14639 /* IntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370ED2ABC6A0B9555D5BFC35 /* IntroView.swift */; };
 		7CAC1F4CFDFFF3870E728CFB /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E6E6FA698BFDCA48CBC1A58 /* Core.framework */; };
@@ -139,6 +143,13 @@
 			remoteGlobalIDString = DCFC6BD53C5504F6AF0FDBDD;
 			remoteInfo = UI;
 		};
+		5088EC77C167C00A2630082F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9DE9128F1973497FDC82560F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0B89B129FD7D90DE26960F7E;
+			remoteInfo = Feature;
+		};
 		52BCDFF33334740B6E65773B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9DE9128F1973497FDC82560F /* Project object */;
@@ -220,6 +231,16 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C1C341E7E2B976AC3A688188 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C4BFA44B177CBB7453D3C6C9 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -269,6 +290,7 @@
 		35DE83C4476D72332B2BB701 /* FindID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindID.swift; sourceTree = "<group>"; };
 		370ED2ABC6A0B9555D5BFC35 /* IntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroView.swift; sourceTree = "<group>"; };
 		4007B3111D84601BEF7F198F /* TuistAssets+ToMyongJiIOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistAssets+ToMyongJiIOS.swift"; sourceTree = "<group>"; };
+		432A6A47ADFAEE9A3AB423B9 /* LoginViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModelTests.swift; sourceTree = "<group>"; };
 		44ED7F91622732D9D7BB4A23 /* CoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		46CA7CB5A54C35737507324C /* ReceiptEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptEndpoint.swift; sourceTree = "<group>"; };
 		4DDAE4F0006E0A0A87059FAD /* TuistFonts+ToMyongJiIOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistFonts+ToMyongJiIOS.swift"; sourceTree = "<group>"; };
@@ -277,6 +299,7 @@
 		55A6CAB10EAD33EE3A98FC25 /* FindIDEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindIDEndpoint.swift; sourceTree = "<group>"; };
 		5641C8AE107F7F5F3EF32CC5 /* CollegesAndClubsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollegesAndClubsView.swift; sourceTree = "<group>"; };
 		56B5171995BA262DFC700D09 /* InputEmailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputEmailView.swift; sourceTree = "<group>"; };
+		572B173E515CAD1851B4D115 /* EndpointEnumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndpointEnumTests.swift; sourceTree = "<group>"; };
 		57B6773E9601E7C09856D053 /* GmarketSansLight.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = GmarketSansLight.otf; sourceTree = "<group>"; };
 		5B36A6E676E49FF5251075A3 /* AlamofireNetworkingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireNetworkingManagerTests.swift; sourceTree = "<group>"; };
 		5DBFAD8D70C6358B8A1B957E /* CustomTF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTF.swift; sourceTree = "<group>"; };
@@ -303,6 +326,7 @@
 		9E0208492746ACB4D68A285C /* ToMyongJi_iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ToMyongJi_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A118F8E51C514435D1F1F614 /* CollegesAndClubsEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollegesAndClubsEndpoint.swift; sourceTree = "<group>"; };
 		A770C1C085DFD23EC9DDFCE1 /* AuthenticationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationView.swift; sourceTree = "<group>"; };
+		A802ED4038E92FAA13DB40F2 /* FeatureTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "FeatureTests-Info.plist"; sourceTree = "<group>"; };
 		A8E04B0F3168EF17B2642BF2 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		AB7EF258DEC112A8B4311E06 /* ClubMemberInfoRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubMemberInfoRow.swift; sourceTree = "<group>"; };
 		ABE866F14C89078EF98DBE63 /* ProfileMyInfoRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileMyInfoRow.swift; sourceTree = "<group>"; };
@@ -317,6 +341,7 @@
 		CB199665032EC73F88149783 /* TuistFonts+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistFonts+UI.swift"; sourceTree = "<group>"; };
 		CBEFE4CBD3A375C18679F105 /* GmarketSansMedium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = GmarketSansMedium.otf; sourceTree = "<group>"; };
 		D38CA0F364AB7F50917E4963 /* InputClubAuthenticationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputClubAuthenticationView.swift; sourceTree = "<group>"; };
+		D6D8D61F6E3827989FE019A7 /* FeatureTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FeatureTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA14A78FB6114C0700674FA4 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		DC04466725ECCF5FD070BAD5 /* CollegesAndClubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollegesAndClubs.swift; sourceTree = "<group>"; };
 		E04969DDCC77A17FF2EE0EBC /* SignUpEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpEndpoint.swift; sourceTree = "<group>"; };
@@ -326,6 +351,7 @@
 		E9496419038EE7CD9CF6E9F4 /* GradientButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientButton.swift; sourceTree = "<group>"; };
 		E9BE8A3EFF47B1A47D5DAA28 /* MaintenanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceView.swift; sourceTree = "<group>"; };
 		E9D55CD4AA05D94B5AAEA1C0 /* CollegesAndClubsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollegesAndClubsViewModel.swift; sourceTree = "<group>"; };
+		EB662513BB59FD2768462EAE /* AuthenticationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationManagerTests.swift; sourceTree = "<group>"; };
 		ECE4A5D80FD0B1BD968309D3 /* AgreeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgreeButton.swift; sourceTree = "<group>"; };
 		F282863C267985B3BA98494A /* AgreementType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgreementType.swift; sourceTree = "<group>"; };
 		F5297ADE6F65CF8664EC4D05 /* IntroViewItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewItem.swift; sourceTree = "<group>"; };
@@ -337,42 +363,20 @@
 		FE47F37DC5E4D08AA9C53989 /* SelectCollegesAndClubsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectCollegesAndClubsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
-/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		F51263172D9BC4FC00EA0071 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				Login/LoginViewModelTests.swift,
-			);
-			target = DE41B31E49415D6F9F1E4580 /* ToMyongJi-iOS */;
-		};
-		F51DD74C2D95195A00249FF0 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				AuthenticationManagerTests.swift,
-			);
-			target = DE41B31E49415D6F9F1E4580 /* ToMyongJi-iOS */;
-		};
-		F5D1CB402D9AA91E00B4A5D5 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				EndpointEnumTests.swift,
-			);
-			target = DE41B31E49415D6F9F1E4580 /* ToMyongJi-iOS */;
-		};
-/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
-
-/* Begin PBXFileSystemSynchronizedRootGroup section */
-		F512630C2D9BBDAA00EA0071 /* Tests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (F51263172D9BC4FC00EA0071 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Tests; sourceTree = "<group>"; };
-		F51DD7482D95194C00249FF0 /* Authentication */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (F51DD74C2D95195A00249FF0 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Authentication; sourceTree = "<group>"; };
-		F5D1CB3C2D9AA90E00B4A5D5 /* Endpoint */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (F5D1CB402D9AA91E00B4A5D5 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Endpoint; sourceTree = "<group>"; };
-/* End PBXFileSystemSynchronizedRootGroup section */
-
 /* Begin PBXFrameworksBuildPhase section */
 		4D4ED60ED788A95753FBFA84 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				817E555668379DF5AE7EC7A7 /* Core.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4EFDF47C3EDE6C13EB17DCAF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				78BCFD39761E82405618839B /* Feature.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -443,8 +447,8 @@
 		0390F904E1F037F08DFFDA45 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				F5D1CB3C2D9AA90E00B4A5D5 /* Endpoint */,
-				F51DD7482D95194C00249FF0 /* Authentication */,
+				FC2FD89CC9CEB554B6091639 /* Authentication */,
+				BE405ECAE8995C57DCDCE14F /* Endpoint */,
 				4B789673EBCAA4E188583135 /* Network */,
 			);
 			path = Tests;
@@ -559,10 +563,18 @@
 		2F2E9C0F39173F477693C062 /* Feature */ = {
 			isa = PBXGroup;
 			children = (
-				F512630C2D9BBDAA00EA0071 /* Tests */,
 				DF1440F8006D5C5CAA0604E2 /* Sources */,
+				30E92F57802149B8CF434BA5 /* Tests */,
 			);
 			path = Feature;
+			sourceTree = "<group>";
+		};
+		30E92F57802149B8CF434BA5 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				9679F70AFD6E1ECFC50B0049 /* Login */,
+			);
+			path = Tests;
 			sourceTree = "<group>";
 		};
 		314BD30F384C44ABEB598D2F /* Services */ = {
@@ -827,6 +839,14 @@
 			path = Services;
 			sourceTree = "<group>";
 		};
+		9679F70AFD6E1ECFC50B0049 /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				432A6A47ADFAEE9A3AB423B9 /* LoginViewModelTests.swift */,
+			);
+			path = Login;
+			sourceTree = "<group>";
+		};
 		98D62B63687AEA0BBD02C6AB /* FindID */ = {
 			isa = PBXGroup;
 			children = (
@@ -938,6 +958,14 @@
 			path = Authentication;
 			sourceTree = "<group>";
 		};
+		BE405ECAE8995C57DCDCE14F /* Endpoint */ = {
+			isa = PBXGroup;
+			children = (
+				572B173E515CAD1851B4D115 /* EndpointEnumTests.swift */,
+			);
+			path = Endpoint;
+			sourceTree = "<group>";
+		};
 		BFBA11CA008D0BD58F944ECD /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -980,6 +1008,7 @@
 				4E6E6FA698BFDCA48CBC1A58 /* Core.framework */,
 				44ED7F91622732D9D7BB4A23 /* CoreTests.xctest */,
 				79E57EC36E48D72F62A7553D /* Feature.framework */,
+				D6D8D61F6E3827989FE019A7 /* FeatureTests.xctest */,
 				9E0208492746ACB4D68A285C /* ToMyongJi_iOS.app */,
 				26515D53170FF30DD2863442 /* UI.framework */,
 			);
@@ -1001,6 +1030,7 @@
 				76B419841B30D48E82E11143 /* Core-Info.plist */,
 				7B8F3A79294BC6BFD0F9E625 /* CoreTests-Info.plist */,
 				F94FA58B29F48CF265E924FE /* Feature-Info.plist */,
+				A802ED4038E92FAA13DB40F2 /* FeatureTests-Info.plist */,
 				F8C703DC525E6154C8D0364C /* UI-Info.plist */,
 			);
 			path = InfoPlists;
@@ -1099,6 +1129,14 @@
 			path = CollegeAndClubs;
 			sourceTree = "<group>";
 		};
+		FC2FD89CC9CEB554B6091639 /* Authentication */ = {
+			isa = PBXGroup;
+			children = (
+				EB662513BB59FD2768462EAE /* AuthenticationManagerTests.swift */,
+			);
+			path = Authentication;
+			sourceTree = "<group>";
+		};
 		FCBF447637BD815CB4124364 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -1126,9 +1164,6 @@
 				D37EC570C4C419799DD8FAA9 /* PBXTargetDependency */,
 				94EA7000270DD73477E09493 /* PBXTargetDependency */,
 			);
-			fileSystemSynchronizedGroups = (
-				F512630C2D9BBDAA00EA0071 /* Tests */,
-			);
 			name = Feature;
 			productName = Feature;
 			productReference = 79E57EC36E48D72F62A7553D /* Feature.framework */;
@@ -1155,6 +1190,25 @@
 			productReference = 04FFD79F3BD12493D40B9FA8 /* App.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		447F7D514FB4DCC020301883 /* FeatureTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A121CB4F8212220CF0EB7D86 /* Build configuration list for PBXNativeTarget "FeatureTests" */;
+			buildPhases = (
+				16F16B8C0AC25D59EAEF409A /* Sources */,
+				BE86F340536A560DC07F8831 /* Resources */,
+				C1C341E7E2B976AC3A688188 /* Embed Frameworks */,
+				4EFDF47C3EDE6C13EB17DCAF /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FE229448DA43E935D6573061 /* PBXTargetDependency */,
+			);
+			name = FeatureTests;
+			productName = FeatureTests;
+			productReference = D6D8D61F6E3827989FE019A7 /* FeatureTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		6931F4368E771245D2A9E17D /* CoreTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2C31BF2EC6ED7E2E6E582383 /* Build configuration list for PBXNativeTarget "CoreTests" */;
@@ -1168,10 +1222,6 @@
 			);
 			dependencies = (
 				EAE2659F444FEA4AD9B511FE /* PBXTargetDependency */,
-			);
-			fileSystemSynchronizedGroups = (
-				F51DD7482D95194C00249FF0 /* Authentication */,
-				F5D1CB3C2D9AA90E00B4A5D5 /* Endpoint */,
 			);
 			name = CoreTests;
 			productName = CoreTests;
@@ -1246,6 +1296,8 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				ORGANIZATIONNAME = ToMyongJi;
+				TargetAttributes = {
+				};
 			};
 			buildConfigurationList = D83261D0E22D58AD5DBEE3E0 /* Build configuration list for PBXProject "ToMyongJi" */;
 			compatibilityVersion = "Xcode 14.0";
@@ -1269,6 +1321,7 @@
 				8BFBC7B529ACBD5B074DBED3 /* Core */,
 				DCFC6BD53C5504F6AF0FDBDD /* UI */,
 				6931F4368E771245D2A9E17D /* CoreTests */,
+				447F7D514FB4DCC020301883 /* FeatureTests */,
 			);
 		};
 /* End PBXProject section */
@@ -1297,6 +1350,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		BE7807152F39386F8990FA89 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BE86F340536A560DC07F8831 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1345,7 +1405,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0AF567CE918C4EF6271CFF3A /* AuthenticationManagerTests.swift in Sources */,
+				0227BAF3C7528EE3AB22DCE4 /* EndpointEnumTests.swift in Sources */,
 				D3A04BC842373FF7FE3FCC12 /* AlamofireNetworkingManagerTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		16F16B8C0AC25D59EAEF409A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4F979A0F9C7493F874BBBA2F /* LoginViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1500,6 +1570,12 @@
 			target = 8BFBC7B529ACBD5B074DBED3 /* Core */;
 			targetProxy = 13215CEB660F1A2F2B15FAC9 /* PBXContainerItemProxy */;
 		};
+		FE229448DA43E935D6573061 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Feature;
+			target = 0B89B129FD7D90DE26960F7E /* Feature */;
+			targetProxy = 5088EC77C167C00A2630082F /* PBXContainerItemProxy */;
+		};
 		FED2FCC18075EF59EF8F3B8B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Core;
@@ -1509,6 +1585,33 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		05D319CADBEACBBD98620C36 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = "Derived/InfoPlists/FeatureTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.tomyongji.featureTests;
+				PRODUCT_NAME = FeatureTests;
+				SDKROOT = iphoneos;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+					"$(inherited)",
+					DEBUG,
+				);
+				SWIFT_COMPILATION_MODE = singlefile;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
 		279E54D50E239577C184636B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1550,13 +1653,39 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+					"$(inherited)",
+					DEBUG,
+				);
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
+		};
+		6EF944936D390D720D76D8BF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = "Derived/InfoPlists/FeatureTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.tomyongji.featureTests;
+				PRODUCT_NAME = FeatureTests;
+				SDKROOT = iphoneos;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
 		};
 		783028E0A748106EB42FFFA9 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1581,7 +1710,10 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+					"$(inherited)",
+					DEBUG,
+				);
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1703,7 +1835,10 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+					"$(inherited)",
+					DEBUG,
+				);
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1757,7 +1892,10 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+					"$(inherited)",
+					DEBUG,
+				);
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1790,7 +1928,10 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+					"$(inherited)",
+					DEBUG,
+				);
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1876,7 +2017,10 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+					"$(inherited)",
+					DEBUG,
+				);
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -2021,6 +2165,15 @@
 			buildConfigurations = (
 				783028E0A748106EB42FFFA9 /* Debug */,
 				ABB646D3D39C96445E0B96D9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A121CB4F8212220CF0EB7D86 /* Build configuration list for PBXNativeTarget "FeatureTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				05D319CADBEACBBD98620C36 /* Debug */,
+				6EF944936D390D720D76D8BF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ToMyongJi.xcodeproj/xcshareddata/xcschemes/Feature.xcscheme
+++ b/ToMyongJi.xcodeproj/xcshareddata/xcschemes/Feature.xcscheme
@@ -26,9 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      disableMainThreadChecker = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "447F7D514FB4DCC020301883"
+               BuildableName = "FeatureTests.xctest"
+               BlueprintName = "FeatureTests"
+               ReferencedContainer = "container:ToMyongJi.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #91 

### 📝작업 내용

> LoginViewModel 테스트 코드 비동기 통신 수정
- async로 되어있는 코드를 combine을 사용해서 수정
- DispatchQueue.main.asyncAfter(deadline: now() +2)를 사용하여 combine 통신이 완료될 때까지 쓰레드에서 2초 기다림
- 로딩 상태 확인 / 에러 상태 확인 / 인증 상태 확인 / 입력 필드 초기화 상태 확인 -> 4개의 상태 검증

### 🔨테스트 결과 > 스크린샷 (선택)

<img width="1440" alt="스크린샷 2025-04-02 오후 4 20 24" src="https://github.com/user-attachments/assets/3fc12e08-8976-48ad-8841-079081c8e4f7" />


