### PR TITLE
Test: SignUpViewModel - 이메일 인증, 소속 인증, 회원가입 프로세스 전체 테스트

### DIFF
--- a/Feature/Sources/CollegeAndClubs/Models/CollegesAndClubs.swift
+++ b/Feature/Sources/CollegeAndClubs/Models/CollegesAndClubs.swift
@@ -22,8 +22,8 @@ struct College: Codable, Identifiable {
 }
 
 struct Club: Codable, Identifiable {
-    let studentClubId: Int
-    let studentClubName: String
+    var studentClubId: Int
+    var studentClubName: String
     
     var id: Int { studentClubId }
 }

--- a/Feature/Sources/SignUp/Models/SignUp.swift
+++ b/Feature/Sources/SignUp/Models/SignUp.swift
@@ -51,14 +51,6 @@ public struct EmailRequest: Codable {
     }
 }
 
-//public struct EmailResponse: Codable {
-//    let code: String
-//    
-//    public init(code: String) {
-//        self.code = code
-//    }
-//}
-
 public struct VerifyCodeRequest: Codable {
     let email: String
     let code: String

--- a/Feature/Sources/SignUp/ViewModels/SignUpViewModel.swift
+++ b/Feature/Sources/SignUp/ViewModels/SignUpViewModel.swift
@@ -32,6 +32,7 @@ class SignUpViewModel {
     var isEmailVerified: Bool = false
     var isClubVerified: Bool = false
     var isUserIdAvailable: Bool = false
+    var isSignUpCompleted: Bool = false
     
     // 데이터
     var colleges: [College] = []
@@ -78,7 +79,7 @@ class SignUpViewModel {
                 }
             } receiveValue: { [weak self] response in
                 guard let self = self else { return }
-                self.verificationCode = response
+//                self.verificationCode = response
                 self.showAlert(title: "알림", message: "인증코드가 발송되었습니다.")
             }
             .store(in: &cancellables)
@@ -124,6 +125,7 @@ class SignUpViewModel {
             } receiveValue: { [weak self]
                 response in
                 guard let self = self else { return }
+                self.showAlert(title: "알림", message: "단과대학 정보를 가져오는 데 성공했습니다.")
                 self.colleges = response.data
             }
             .store(in: &cancellables)
@@ -131,8 +133,9 @@ class SignUpViewModel {
     
     // 소속 인증
     func verifyClub() {
-        guard let clubId = selectedClub?.studentClubId else { return }
-        let request = ClubVerifyRequest(clubId: clubId, studentNum: studentNum, role: selectedRole)
+        guard let cludId = selectedClub?.studentClubId else { return }
+        
+        let request = ClubVerifyRequest(clubId: cludId, studentNum: studentNum, role: selectedRole)
         networkingManager.run(SignUpEndpoint.verifyClub(request), type: ClubVerifyResponse.self)
             .sink { [weak self] completion in
                 guard let self = self else { return }
@@ -146,7 +149,7 @@ class SignUpViewModel {
                 guard let self = self else { return }
                 self.isClubVerified = response.data
                 if response.data {
-                    self.showAlert(title: "알림", message: "소속이 인증되었습니다.")
+                    self.showAlert(title: "알림", message: "소속 인증에 성공했습니다.")
                 } else {
                     self.showAlert(title: "알림", message: "소속 인증에 실패했습니다.")
                 }
@@ -181,7 +184,8 @@ class SignUpViewModel {
             } receiveValue: { [weak self] response in
                 guard let self = self else { return }
                 if response.statusCode == 200 {
-                    self.showAlert(title: "알림", message: "회원가입이 완료되었습니다.")
+                    self.showAlert(title: "알림", message: "회원가입에 성공했습니다.")
+                    self.isSignUpCompleted = true
                     completion(true)
                 } else {
                     self.showAlert(title: "오류", message: "회원가입에 실패했습니다.")

--- a/Feature/Tests/SignUp/SignUpViewModelTests.swift
+++ b/Feature/Tests/SignUp/SignUpViewModelTests.swift
@@ -71,4 +71,166 @@ final class SignUpViewModelTests: XCTestCase {
         
         wait(for: [expectation], timeout: 4.0)
     }
+    
+    // MARK: - 이메일 인증코드 확인 테스트
+    
+    func test_WhenVerifyEmailCodeSuccess_ThenIsEmailVerifiedTrue() {
+        // given
+        sut.email = "junnkyuu22@gmail.com"
+        let expectation = XCTestExpectation(description: "이메일이 인증되었습니다.")
+        
+        // when
+        sut.sendVerificationEmail()
+        
+        // then
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+            XCTAssertNotEqual(self.sut.verificationCode, "")
+            
+            self.sut.verifyEmailCode()
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                
+                XCTAssertTrue(self.sut.isEmailVerified)
+                XCTAssertTrue(self.sut.showAlert)
+                XCTAssertEqual(self.sut.alertMessage, "이메일 인증되었습니다.")
+                
+                expectation.fulfill()
+            }
+        }
+    }
+    
+    // MARK: - 단과대학 및 소속 정보 가져오기 테스트
+    
+    func test_WhenFetchCollegesSuccess_ThenCollegesAndClubsNotEmpty() {
+        
+        // given
+        let expectation = XCTestExpectation(description: "단과대학 정보를 가져오는 데 성공했습니다.")
+        
+        // when
+        sut.fetchColleges()
+        
+        // then
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+            
+            // 1. 알림 상태 확인
+            XCTAssertTrue(self.sut.showAlert)
+            XCTAssertEqual(self.sut.alertMessage, "단과대학 정보를 가져오는 데 성공했습니다.")
+            
+            // 2. 단과대학 정보 확인
+            XCTAssertFalse(self.sut.colleges.isEmpty)
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 5.0)
+    }
+    
+    // MARK: - 소속 인증 테스트
+    
+    func test_WhenClubVerifySuccess_ThenIsClubVerifiedTrue() {
+        
+        // given
+        sut.selectedClub = Club(studentClubId: 3, studentClubName: "국어국문학전공 학생회")
+        sut.studentNum = "77777777"
+        sut.selectedRole = "STU"
+        let expectation = XCTestExpectation(description: "소속 인증에 성공했습니다.")
+        
+        // when
+        sut.verifyClub()
+        
+        // then
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+            // 1. 알림 상태 확인
+            XCTAssertTrue(self.sut.showAlert)
+            XCTAssertEqual(self.sut.alertMessage, "소속 인증에 성공했습니다.")
+            
+            // 2. 테스트 값 확인
+            XCTAssertEqual(self.sut.selectedClub?.studentClubId, 3)
+            XCTAssertEqual(self.sut.studentNum, "77777777")
+            XCTAssertEqual(self.sut.selectedRole, "STU")
+            
+            // 3. 소속 인증 상태 확인
+            XCTAssertTrue(self.sut.isClubVerified)
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 5.0)
+    }
+    
+    // MARK: - 회원가입 전체 프로세스 테스트
+    
+    func test_WhenCompleteSignUpProcess_ThenSignUpSuccess() {
+        // 1. 아이디 중복 체크
+        let userIdExpectation = XCTestExpectation(description: "사용가능한 아이디입니다.")
+        sut.userId = "sonny7"
+        
+        sut.checkUserId()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            XCTAssertTrue(self.sut.isUserIdAvailable)
+            XCTAssertEqual(self.sut.alertMessage, "사용가능한 아이디입니다.")
+            userIdExpectation.fulfill()
+        }
+        
+        wait(for: [userIdExpectation], timeout: 5.0)
+        
+        // 2. 이메일 인증
+        let emailExpectation = XCTestExpectation(description: "이메일이 인증되었습니다.")
+        sut.email = "junnkyuu22@gmail.com"
+        
+        // 이메일 인증코드 발송
+        sut.sendVerificationEmail()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            XCTAssertNotEqual(self.sut.verificationCode, "")
+            XCTAssertEqual(self.sut.alertMessage, "인증코드가 발송되었습니다.")
+            
+            // 이메일 인증코드 확인
+            self.sut.verifyEmailCode()
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                XCTAssertTrue(self.sut.isEmailVerified)
+                XCTAssertEqual(self.sut.alertMessage, "이메일이 인증되었습니다.")
+                emailExpectation.fulfill()
+            }
+        }
+        
+        wait(for: [emailExpectation], timeout: 12.0)
+        
+        // 3. 소속 인증
+        let clubExpectation = XCTestExpectation(description: "소속 인증에 성공했습니다.")
+        sut.name = "손흥민"
+        sut.studentNum = "77777777"
+        sut.selectedCollege = College(collegeId: 2, collegeName: "인문대학", clubs: [
+            Club(studentClubId: 3, studentClubName: "국어국문학전공 학생회"),
+        ])
+        sut.selectedClub = Club(studentClubId: 3, studentClubName: "국어국문학전공 학생회")
+        sut.selectedRole = "STU"
+        
+        sut.verifyClub()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            XCTAssertTrue(self.sut.isClubVerified)
+            XCTAssertEqual(self.sut.alertMessage, "소속 인증에 성공했습니다.")
+            clubExpectation.fulfill()
+        }
+        
+        wait(for: [clubExpectation], timeout: 7.0)
+        
+        // 4. 회원가입
+        let signUpExpectation = XCTestExpectation(description: "회원가입에 성공했습니다.")
+        sut.password = "Leejunkyu87@@"
+        
+        sut.signUp { [weak self] success in
+            guard let self = self else { return }
+            XCTAssertTrue(success)
+            XCTAssertTrue(self.sut.showAlert)
+            XCTAssertEqual(self.sut.alertMessage, "회원가입에 성공했습니다.")
+            XCTAssertTrue(self.sut.isSignUpCompleted)
+            signUpExpectation.fulfill()
+        }
+        
+        wait(for: [signUpExpectation], timeout: 20.0)
+    }
 }


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #91 

### 📝작업 내용

> SignUpViewModel - 이메일 인증, 소속 인증, 회원가입 프로세스 전체 테스트

- 이메일 인증 테스트
- 소속 인증 테스트
- 아이디 중복 -> 이메일 인증 코드 발송 -> 이메일 인증 -> 소속 인증 -> 회원가입 진행 프로세스 전체 테스트

### 🔨테스트 결과 > 스크린샷 (선택)

![스크린샷 2025-04-11 오후 5 28 13(2)](https://github.com/user-attachments/assets/880a6128-434c-4b65-a90f-8b70a0965c48)

<img width="872" alt="image" src="https://github.com/user-attachments/assets/539792cb-1b1b-4baa-95f7-08428a294024" />

