### PR TITLE
Feature: 일반 학생/학생회 전용 영수증 조회 기능 구현

### DIFF
--- a/Feature/Sources/Receipts/Models/Receipt.swift
+++ b/Feature/Sources/Receipts/Models/Receipt.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-// 영수증 조회
+// MARK: - 영수증 조회
 public struct ReceiptResponse: Codable {
     let statusCode: Int
     let statusMessage: String
@@ -22,6 +22,27 @@ public struct ReceiptResponse: Codable {
 
 public struct ReceiptData: Codable {
     let receiptList: [Receipt]
+    
+    public init(receiptList: [Receipt]) {
+        self.receiptList = receiptList
+    }
+}
+
+// MARK: - 학생회를 위한 영수증 조회
+public struct ReceiptForStudentClubResponse: Codable {
+    let statusCode: Int
+    let statusMessage: String
+    let data: RecieptForStudentClubData
+    
+    public init(statusCode: Int, statusMessage: String, data: RecieptForStudentClubData) {
+        self.statusCode = statusCode
+        self.statusMessage = statusMessage
+        self.data = data
+    }
+}
+
+public struct RecieptForStudentClubData: Codable {
+    let receiptList: [Receipt]
     let balance: Int
     
     public init(receiptList: [Receipt], balance: Int) {
@@ -30,7 +51,8 @@ public struct ReceiptData: Codable {
     }
 }
 
-// 영수증 작성
+
+// MARK: - 영수증 작성
 public struct CreateReceiptRequest: Codable {
     let userId: String
     let date: String
@@ -75,7 +97,7 @@ public struct SingleReceiptData: Codable {
     }
 }
 
-// 영수증
+// MARK: - 영수증
 public struct Receipt: Identifiable, Codable {
     public let id: UUID = UUID()
     let receiptId: Int
@@ -97,7 +119,7 @@ public struct Receipt: Identifiable, Codable {
     }
 }
 
-// 영수증 삭제
+// MARK: - 영수증 삭제
 public struct DeleteReceiptResponse: Codable {
     let statusCode: Int
     let statusMessage: String

--- a/Feature/Sources/Receipts/Services/ReceiptEndpoint.swift
+++ b/Feature/Sources/Receipts/Services/ReceiptEndpoint.swift
@@ -12,6 +12,7 @@ import Core
 
 public enum ReceiptEndpoint {
     case receipt(studentClubId: Int)
+    case receiptForStudentClub(userId: Int)
     case createReceipt(CreateReceiptRequest)
     case deleteReceipt(receiptId: Int)
 }
@@ -20,7 +21,9 @@ extension ReceiptEndpoint: Endpoint {
     public var path: String {
         switch self {
         case .receipt(let studentClubId):
-            return "/api/receipt/club/\(studentClubId)"
+            return "/api/receipt/club/\(studentClubId)/student"
+        case .receiptForStudentClub(let userId):
+            return "/api/receipt/club/\(userId)"
         case .createReceipt:
             return "/api/receipt"
         case .deleteReceipt(let receiptId):
@@ -59,7 +62,7 @@ extension ReceiptEndpoint: Endpoint {
     
     public var method: HTTPMethod {
         switch self {
-        case .receipt:
+        case .receipt, .receiptForStudentClub:
             return .get
         case .createReceipt:
             return .post
@@ -70,12 +73,10 @@ extension ReceiptEndpoint: Endpoint {
     
     public var encoding: ParameterEncoding {
         switch self {
-        case .receipt:
+        case .receipt, .receiptForStudentClub, .deleteReceipt:
             return URLEncoding.default
         case .createReceipt:
             return JSONEncoding.default
-        case .deleteReceipt:
-            return URLEncoding.default
         }
     }
 }


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #85 

### 📝작업 내용

> 일반 학생/학생회 전용 영수증 조회 기능 구현
- 사용자 피드백을 바탕으로 잔액은 학생회 구성원만 보이게 수정
- endpoint를 일반 학생용/학생회 전용으로 구분해서 영수증 조회 기능 구현

### 🔨테스트 결과 > 스크린샷 (선택)

<img width="1440" alt="스크린샷 2025-04-15 오후 3 53 48" src="https://github.com/user-attachments/assets/a92a40db-7129-4918-baed-9ff9d431550b" />


