### PR TITLE
Test: ReceiptViewModelTests - 로그인을 통한 토큰 사용, 영수증 조회, 추가, 삭제 통합 테스트

### DIFF
--- a/Feature/Tests/Profile/ProfileViewModelTests.swift
+++ b/Feature/Tests/Profile/ProfileViewModelTests.swift
@@ -8,7 +8,6 @@
 
 import XCTest
 @testable import Feature
-@testable import Core
 
 final class ProfileViewModelTests: XCTestCase {
     var profileSut: ProfileViewModel!
@@ -39,7 +38,7 @@ final class ProfileViewModelTests: XCTestCase {
         try super.tearDownWithError()
         profileSut = nil
         loginSut = nil
-        AuthenticationManager.shared.clearAuthentication()
+        loginSut.authManager.clearAuthentication()
     }
     
     // MARK: - 유저 정보 조회 테스트

--- a/Feature/Tests/Receipts/ReceiptViewModelTests.swift
+++ b/Feature/Tests/Receipts/ReceiptViewModelTests.swift
@@ -7,73 +7,127 @@
 //
 
 import XCTest
-import Core
-import Combine
 @testable import Feature
 
 final class ReceiptViewModelTests: XCTestCase {
-    var sut: ReceiptViewModel!
+    var receiptSut: ReceiptViewModel!
+    var loginSut: LoginViewModel!
     
     override func setUpWithError() throws {
         try super.setUpWithError()
-        sut = ReceiptViewModel()
+        receiptSut = ReceiptViewModel()
+        loginSut = LoginViewModel()
+        
+        // 로그인 처리
+        let loginExpectation = XCTestExpectation(description: "로그인 완료")
+        
+        loginSut.userId = "tomyongji"
+        loginSut.password = "Tomyongji123!"
+        loginSut.login()
+        
+        // 로그인 완료 대기
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [weak self] in
+            guard let self = self else { return }
+            
+            // 로그인 상태 확인
+            XCTAssertTrue(self.loginSut.isSuccess, "로그인이 실패했습니다.")
+            XCTAssertTrue(self.loginSut.authManager.isAuthenticated, "인증 상태가 아닙니다.")
+            XCTAssertNotNil(self.loginSut.authManager.userId, "userId가 nil입니다.")
+            
+            loginExpectation.fulfill()
+        }
+        
+        wait(for: [loginExpectation], timeout: 10.0)
+        
+        // 로그인 실패 시 테스트 중단
+        guard loginSut.isSuccess,
+              loginSut.authManager.isAuthenticated,
+              loginSut.authManager.userId != nil else {
+            XCTFail("로그인 설정이 실패했습니다.")
+            return
+        }
     }
     
     override func tearDownWithError() throws {
         try super.tearDownWithError()
-        sut = nil
+        
+        // 인증 정보 초기화
+        loginSut.authManager.clearAuthentication()
+        
+        // 객체 해제
+        receiptSut = nil
+        loginSut = nil
     }
     
     // MARK: - 영수증 조회 테스트
     
     func test_WhenFetchReceiptsSuccess_ThenGetReceipts() {
         // given
-        let testStudentClubId: Int = 3
+        let testStudentClubId = 3
+        let expectation = XCTestExpectation(description: "영수증 조회 완료")
         
         // when
-        sut.getReceipts(studentClubId: testStudentClubId)
+        receiptSut.getReceipts(studentClubId: testStudentClubId)
         
         // then
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            [weak self] in
+                guard let self = self else { return }
+            
             // 1. 로딩 상태 확인
-            XCTAssertFalse(self.sut.isLoading)
+            XCTAssertFalse(self.receiptSut.isLoading)
             
             // 2. 영수증 데이터 상태 확인
-            XCTAssertNotEqual(self.sut.receipts.count, 0)
-            XCTAssertNotEqual(self.sut.filteredReceipts.count, 0)
+            XCTAssertNotEqual(self.receiptSut.receipts.count, 0)
+            XCTAssertNotEqual(self.receiptSut.filteredReceipts.count, 0)
+            
+            expectation.fulfill()
         }
         
+        wait(for: [expectation], timeout: 5.0)
     }
     
     // MARK: - 학생회 전용 영수증 조회 테스트
     
     func test_WhenFetchStudentClubReceiptsSuccess_ThenGetStudentClubReceipts() {
         // given
-        let testUserId: Int = 102
+        let expectation = XCTestExpectation(description: "학생회 영수증 조회 완료")
+        
+        // 로그인 상태 확인
+        guard let userId = loginSut.authManager.userId else {
+            XCTFail("userId가 nil입니다. 로그인이 필요합니다.")
+            return
+        }
         
         // when
-        sut.getStudentClubReceipts(userId: testUserId)
+        receiptSut.getStudentClubReceipts(userId: userId)
         
         // then
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+            guard let self = self else { return }
+            
             // 1. 로딩 상태 확인
-            XCTAssertFalse(self.sut.isLoading)
+            XCTAssertFalse(self.receiptSut.isLoading)
             
             // 2. 영수증 데이터 상태 확인
-            XCTAssertNotEqual(self.sut.receipts.count, 0)
-            XCTAssertNotEqual(self.sut.filteredReceipts.count, 0)
-            XCTAssertNotEqual(self.sut.balance, 0)
+            XCTAssertNotEqual(self.receiptSut.receipts.count, 0)
+            XCTAssertNotEqual(self.receiptSut.filteredReceipts.count, 0)
+            XCTAssertNotEqual(self.receiptSut.balance, 0)
+            
+            expectation.fulfill()
         }
+        
+        wait(for: [expectation], timeout: 5.0)
     }
     
     // MARK: - 영수증 월별 필터링 테스트
     
     func test_WhenFilterReceiptsByMonth_ThenGetFilteredReceipts() {
         // given
-        sut.isFiltered = true
-        sut.selectedMonth = 1
+        receiptSut.isFiltered = true
+        receiptSut.selectedMonth = 1
         
-        sut.receipts = [
+        receiptSut.receipts = [
             Receipt(receiptId: 1, date: "2025-03-01", content: "테스트1", deposit: 1000, withdrawal: 0),
             Receipt(receiptId: 1, date: "2025-04-01", content: "테스트2", deposit: 0, withdrawal: 11000),
             Receipt(receiptId: 1, date: "2025-02-01", content: "테스트3", deposit: 0, withdrawal: 2000000),
@@ -82,12 +136,12 @@ final class ReceiptViewModelTests: XCTestCase {
         ]
         
         // when
-        sut.filterReceipts()
+        receiptSut.filterReceipts()
         
         // then
-        XCTAssertEqual(self.sut.receipts.count, 5)
-        XCTAssertEqual(self.sut.filteredReceipts.count, 2)
-        XCTAssertEqual(self.sut.filteredReceipts[0].date, "2025-01-21")
+        XCTAssertEqual(self.receiptSut.receipts.count, 5)
+        XCTAssertEqual(self.receiptSut.filteredReceipts.count, 2)
+        XCTAssertEqual(self.receiptSut.filteredReceipts[0].date, "2025-01-21")
     }
     
     // MARK: - 영수증 생성 테스트
@@ -96,43 +150,49 @@ final class ReceiptViewModelTests: XCTestCase {
         // given
         let expectation = XCTestExpectation(description: "영수증 작성 완료")
         
-        sut.userLoginId = "tomyongji"
-        sut.date = "2025-04-17"
-        sut.content = "테스트 영수증"
-        sut.deposit = 1000
-        sut.withdrawal = 0
+        // 로그인 상태 확인
+        guard let testUserLoginId = loginSut.authManager.userLoginId else {
+            XCTFail("userLoginId가 nil입니다. 로그인이 필요합니다.")
+            return
+        }
+        
+        receiptSut.userLoginId = testUserLoginId
+        receiptSut.date = "2025-05-08"
+        receiptSut.content = "테스트 영수증"
+        receiptSut.deposit = 4000
+        receiptSut.withdrawal = 0
         
         // when
-        sut.createReceipt()
+        receiptSut.createReceipt()
         
         // then
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
             guard let self = self else { return }
             
             // 1. 로딩 상태 확인
-            XCTAssertFalse(self.sut.isLoading)
+            XCTAssertFalse(self.receiptSut.isLoading)
             
             // 2. 알림 상태 확인
-            XCTAssertTrue(self.sut.showAlert)
+            XCTAssertTrue(self.receiptSut.showAlert)
             
             // 3. 성공/실패 여부에 따른 검증
-            if self.sut.alertMessage == "영수증 작성에 성공했습니다." {
+            if self.receiptSut.alertMessage == "영수증 작성에 성공했습니다." {
                 // 성공 케이스
-                XCTAssertEqual(self.sut.alertTitle, "성공")
-                XCTAssertEqual(self.sut.date, "")
-                XCTAssertEqual(self.sut.content, "")
-                XCTAssertEqual(self.sut.deposit, 0)
-                XCTAssertEqual(self.sut.withdrawal, 0)
+                XCTAssertEqual(self.receiptSut.alertTitle, "성공")
+                XCTAssertEqual(self.receiptSut.date, "")
+                XCTAssertEqual(self.receiptSut.content, "")
+                XCTAssertEqual(self.receiptSut.deposit, 0)
+                XCTAssertEqual(self.receiptSut.withdrawal, 0)
             } else {
                 // 실패 케이스
-                XCTAssertEqual(self.sut.alertTitle, "실패")
-                XCTAssertEqual(self.sut.alertMessage, "영수증 작성에 실패했습니다.")
+                XCTAssertEqual(self.receiptSut.alertTitle, "실패")
+                XCTAssertEqual(self.receiptSut.alertMessage, "영수증 작성에 실패했습니다.")
                 
                 // 입력 필드는 초기화되지 않아야 함
-                XCTAssertEqual(self.sut.date, "2025-04-17")
-                XCTAssertEqual(self.sut.content, "테스트 영수증")
-                XCTAssertEqual(self.sut.deposit, 1000)
-                XCTAssertEqual(self.sut.withdrawal, 0)
+                XCTAssertEqual(self.receiptSut.date, "2025-05-08")
+                XCTAssertEqual(self.receiptSut.content, "테스트 영수증")
+                XCTAssertEqual(self.receiptSut.deposit, 4000)
+                XCTAssertEqual(self.receiptSut.withdrawal, 0)
             }
             
             expectation.fulfill()
@@ -145,28 +205,28 @@ final class ReceiptViewModelTests: XCTestCase {
     
     func test_WhenDeleteReceiptSuccess_ThenGetDeletedReceipt() {
         // given
-        let testReceiptId: Int = 310
+        let testReceiptId: Int = 322
         let testStudentClubId: Int = 3
         let expectation = XCTestExpectation(description: "영수증 삭제에 성공했습니다.")
         
         // when
-        sut.deleteReceipt(receiptId: testReceiptId, studentClubId: testStudentClubId)
+        receiptSut.deleteReceipt(receiptId: testReceiptId, studentClubId: testStudentClubId)
         
         // then
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
             // 1. 로딩 상태 확인
-            XCTAssertFalse(self.sut.isLoading)
+            XCTAssertFalse(self.receiptSut.isLoading)
             
             // 2. 알림 상태 확인
-            XCTAssertTrue(self.sut.showAlert)
+            XCTAssertTrue(self.receiptSut.showAlert)
             
             // 3. 성공/실패 여부에 따른 검증
-            if self.sut.alertMessage == "영수증 삭제에 성공했습니다." {
-                XCTAssertEqual(self.sut.alertTitle, "성공")
-                XCTAssertEqual(self.sut.alertMessage, "영수증 삭제에 성공했습니다.")
+            if self.receiptSut.alertMessage == "영수증 삭제에 성공했습니다." {
+                XCTAssertEqual(self.receiptSut.alertTitle, "성공")
+                XCTAssertEqual(self.receiptSut.alertMessage, "영수증 삭제에 성공했습니다.")
             } else {
-                XCTAssertEqual(self.sut.alertTitle, "실패")
-                XCTAssertEqual(self.sut.alertMessage, "영수증 삭제에 실패했습니다.")
+                XCTAssertEqual(self.receiptSut.alertTitle, "실패")
+                XCTAssertEqual(self.receiptSut.alertMessage, "영수증 삭제에 실패했습니다.")
             }
             
             expectation.fulfill()

--- a/Project.swift
+++ b/Project.swift
@@ -96,7 +96,6 @@ let project = Project(
             infoPlist: .extendingDefault(with: [:]),
             sources: ["Feature/Tests/**"],
             dependencies: [
-                .target(name: "Core"),
                 .target(name: "Feature")
             ]
         )

--- a/ToMyongJi.xcodeproj/project.pbxproj
+++ b/ToMyongJi.xcodeproj/project.pbxproj
@@ -44,7 +44,6 @@
 		439B1E0DDAC7DDCFD4661D45 /* MonthPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6502D342639F99F469DFFD /* MonthPickerView.swift */; };
 		4717D3205BEBECFF15468204 /* SignUpAgreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131942CF256661618987D380 /* SignUpAgreeView.swift */; };
 		4768A3DC7C1892F0FA9B49CF /* GmarketSansBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7F4EE414B972F985522AAC3F /* GmarketSansBold.otf */; };
-		4F96D765313209DD3D524270 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E6E6FA698BFDCA48CBC1A58 /* Core.framework */; };
 		4F979A0F9C7493F874BBBA2F /* LoginViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 432A6A47ADFAEE9A3AB423B9 /* LoginViewModelTests.swift */; };
 		505C4B116508D151AF3961B0 /* SignUpViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E6902EC00D9051FA198300E /* SignUpViewModelTests.swift */; };
 		50AD9E71978D1F56DB597DF9 /* InputEmailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B5171995BA262DFC700D09 /* InputEmailView.swift */; };
@@ -126,13 +125,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = DCFC6BD53C5504F6AF0FDBDD;
 			remoteInfo = UI;
-		};
-		0B2B3A97FD723658D7A6BC31 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9DE9128F1973497FDC82560F /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8BFBC7B529ACBD5B074DBED3;
-			remoteInfo = Core;
 		};
 		0F86034092DCB4C7B801293B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -392,7 +384,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4F96D765313209DD3D524270 /* Core.framework in Frameworks */,
 				78BCFD39761E82405618839B /* Feature.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1255,7 +1246,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				4E4D993D9CB5E09B99C21EE4 /* PBXTargetDependency */,
 				FE229448DA43E935D6573061 /* PBXTargetDependency */,
 			);
 			name = FeatureTests;
@@ -1580,12 +1570,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		4E4D993D9CB5E09B99C21EE4 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Core;
-			target = 8BFBC7B529ACBD5B074DBED3 /* Core */;
-			targetProxy = 0B2B3A97FD723658D7A6BC31 /* PBXContainerItemProxy */;
-		};
 		6226B1EE91370DA7FD0C5943 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = UI;


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #91 

### 📝작업 내용

> Test: ReceiptViewModelTests - 로그인을 통한 토큰 사용, 영수증 조회, 추가, 삭제 통합 테스트
- 로그인을 통한 토큰 사용, 영수증 조회, 추가, 삭제 통합 테스트
- Project.swift의 Core 모듈 의존성 제거

### 🔨테스트 결과 > 스크린샷 (선택)

<img width="1440" alt="스크린샷 2025-05-08 오후 5 07 14" src="https://github.com/user-attachments/assets/2feb24d8-82a4-4386-9da3-29541db13c32" />

<img width="525" alt="image" src="https://github.com/user-attachments/assets/ba66bd87-ab2c-41df-aa61-4b71ea346da1" />


