### PR TITLE
Fix: 옵셔널 언래핑 오류 방지를 위해 tearDownWithError 내 리소스 해제 순서 수정

### DIFF
--- a/Feature/Tests/Profile/ProfileViewModelTests.swift
+++ b/Feature/Tests/Profile/ProfileViewModelTests.swift
@@ -36,9 +36,10 @@ final class ProfileViewModelTests: XCTestCase {
     
     override func tearDownWithError() throws {
         try super.tearDownWithError()
+        loginSut.authManager.clearAuthentication()
+        
         profileSut = nil
         loginSut = nil
-        loginSut.authManager.clearAuthentication()
     }
     
     // MARK: - 유저 정보 조회 테스트
@@ -49,9 +50,7 @@ final class ProfileViewModelTests: XCTestCase {
         profileSut.fetchUserProfile()
         
         // then
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
-            guard let self = self else { return }
-            
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
             // 1. 로딩 상태 확인
             XCTAssertFalse(self.profileSut.isLoading)
             

--- a/Feature/Tests/Receipts/ReceiptViewModelTests.swift
+++ b/Feature/Tests/Receipts/ReceiptViewModelTests.swift
@@ -205,7 +205,7 @@ final class ReceiptViewModelTests: XCTestCase {
     
     func test_WhenDeleteReceiptSuccess_ThenGetDeletedReceipt() {
         // given
-        let testReceiptId: Int = 322
+        let testReceiptId: Int = 325
         let testStudentClubId: Int = 3
         let expectation = XCTestExpectation(description: "영수증 삭제에 성공했습니다.")
         


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #91 

### 📝작업 내용

> Fix: 옵셔널 언래핑 오류 방지를 위해 tearDownWithError 내 리소스 해제 순서 수정
- ProfileViewModelTests, ReceiptViewModelTests의 옵셔널 언래핑 오류 해결
- tearDownWithError의 로그인 관련 정보를 초기화 코드 위치를 수정

### 🔨테스트 결과 > 스크린샷 (선택)

<img width="1440" alt="스크린샷 2025-05-08 오후 5 36 56" src="https://github.com/user-attachments/assets/1aee0379-1d70-410a-a9ca-8445a4b037e5" />


