### PR TITLE
CICD: ios.yml Ruby 3.2 -> 3.1, Bundler 2.4.22

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -20,14 +20,14 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
-          bundler-cache: true
+          ruby-version: '3.1'
       - name: Install tuist
         run: brew install tuist
       - name: Tuist Generate
         run: tuist generate
       - name: Install dependencies
         run: |
+          gem install bundler:2.4.22
           bundle install
           bundle exec pod install
       - name: Create AuthKey.p8
@@ -49,14 +49,14 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
-          bundler-cache: true
+          ruby-version: '3.1'
       - name: Install tuist
         run: brew install tuist
       - name: Tuist Generate
         run: tuist generate
       - name: Install dependencies
         run: |
+          gem install bundler:2.4.22
           bundle install
           bundle exec pod install
       - name: Create AuthKey.p8

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,6 +1,3 @@
-# app_identifier("[[APP_IDENTIFIER]]") # The bundle identifier of your app
-# apple_id("[[APPLE_ID]]") # Your Apple Developer Portal username
-
 app_identifier("com.tomyongji.ios") # 앱의 번들 ID
 apple_id("junnkyuu22@gmail.com") # App Store Connect 계정 이메일
 team_id("FN67GXC5GH") # Apple Developer Team ID
@@ -13,6 +10,3 @@ api_key(
   duration: 1200,
   in_house: false
 )
-
-# For more information about the Appfile, see:
-#     https://docs.fastlane.tools/advanced/#appfile

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -75,6 +75,3 @@ platform :ios do
     )
   end
 end
-
-# CI/CD 환경에서는 반드시 워크플로우에서 tuist generate를 먼저 실행하세요!
-# 인증서 저장소, MATCH_PASSWORD 등은 GitHub Secrets로 관리하세요.


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #59 

### 📝작업 내용

> CICD: ios.yml Ruby 3.2 -> 3.1, Bundler 2.4.22
- ruby, bundler 호환성 문제로 인한 버전 수정

