### PR TITLE
Fix: 영수증 swipeActions 색상 및 CustomTF 입력 최적화

### DIFF
--- a/Feature/Sources/Receipts/Views/CreateReceiptView.swift
+++ b/Feature/Sources/Receipts/Views/CreateReceiptView.swift
@@ -134,6 +134,7 @@ struct CreateReceiptView: View {
                                 } label: {
                                     Label("삭제", systemImage: "trash")
                                 }
+                                .tint(Color.withdrawal)
                                 
                                 Button {
                                     viewModel.setReceiptForUpdate(receipt)
@@ -141,7 +142,7 @@ struct CreateReceiptView: View {
                                 } label: {
                                     Label("수정", systemImage: "pencil")
                                 }
-                                .tint(.blue)
+                                .tint(Color.deposit)
                             }
                     }
                 }

--- a/UI/Sources/Components/CustomTF.swift
+++ b/UI/Sources/Components/CustomTF.swift
@@ -61,6 +61,8 @@ public struct CustomTF: View {
                                     RoundedRectangle(cornerRadius: 12)
                                         .stroke(isFocused ? Color.softBlue : Color.gray.opacity(0.2), lineWidth: 1.5)
                                 )
+                                .autocorrectionDisabled(true)
+                                .textInputAutocapitalization(.never)
                         } else {
                             SecureField(hint, text: $value)
                                 .font(.custom("GmarketSansLight", size: 14))
@@ -76,6 +78,8 @@ public struct CustomTF: View {
                                     RoundedRectangle(cornerRadius: 12)
                                         .stroke(isFocused ? Color.softBlue : Color.gray.opacity(0.2), lineWidth: 1.5)
                                 )
+                                .autocorrectionDisabled(true)
+                                .textInputAutocapitalization(.never)
                         }
                     }
                 } else {
@@ -92,6 +96,8 @@ public struct CustomTF: View {
                             RoundedRectangle(cornerRadius: 12)
                                 .stroke(isFocused ? Color.softBlue : Color.gray.opacity(0.2), lineWidth: 1.5)
                         )
+                        .autocorrectionDisabled(true)
+                        .textInputAutocapitalization(.never)
                 }
             }
             .animation(.easeInOut(duration: 0.2), value: isFocused)


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

### 📝작업 내용

Fix: 영수증 swipeActions 색상 및 CustomTF 입력 최적화

### 🔨테스트 결과 > 스크린샷 (선택)

> 테스트 결과나 스크린 샷으로 보여줘야하는 부분을 삽입해주세요,
### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

