### PR TITLE
ui: 로그인 뷰 디자인 개선

### DIFF
--- a/Feature/Sources/Login/Views/LoginView.swift
+++ b/Feature/Sources/Login/Views/LoginView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import Core
+import UI
 
 struct LoginView: View {
     @Environment(\.dismiss) private var dismiss
@@ -31,15 +32,12 @@ struct LoginView: View {
                         UserDefaults.standard.set(1, forKey: "selectedTab")
                     }
                 }) {
-                    Image(systemName: "chevron.left")
-                        .font(.title3.bold())
-                        .foregroundStyle(Color.darkNavy)
-                        .contentShape(.rect)
+                    DismissButton()
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 
                 Spacer()
-                    .frame(height: 50)
+                    .frame(height: 10)
                 
                 // 로고 이미지 - 크기 유지
                 Image("logo")
@@ -49,11 +47,19 @@ struct LoginView: View {
                     .padding(.vertical, 50)
                 
                 // 입력 필드들을 감싸는 카드 뷰
-                VStack(spacing: 0) {
+                VStack(spacing: 10) {
                     // 아이디 입력
                     TextField("아이디", text: $viewModel.userId)
                         .font(.custom("GmarketSansLight", size: 15))
                         .padding()
+                        .background(Color.white)
+                        .clipShape(
+                            RoundedRectangle(cornerRadius: 10)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(Color("gray_20"), lineWidth: 1)
+                        )
                         .focused($focusField, equals: .id)
                         .autocorrectionDisabled(true)
                         .textInputAutocapitalization(.never)
@@ -61,35 +67,38 @@ struct LoginView: View {
                         .onSubmit {
                             focusField = .password
                         }
-                    
-                    Divider()
-                        .background(Color.gray.opacity(0.2))
-                    
+                        
                     // 비밀번호 입력
                     SecureField("비밀번호", text: $viewModel.password)
                         .font(.custom("GmarketSansLight", size: 15))
                         .padding()
+                        .background(Color.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(Color("gray_20"), lineWidth: 1)
+                        )
                         .focused($focusField, equals: .password)
                         .submitLabel(.done)
                         .onSubmit {
                             viewModel.login()
                         }
+                        
+                    
                 }
-                .background(Color.gray.opacity(0.1))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
                 
                 // 로그인 버튼
                 Button(action: {
                     viewModel.login()
                 }) {
-                    Text("로그인")
+                    Text("다음")
                         .font(.custom("GmarketSansMedium", size: 16))
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 15)
                         .background(
                             RoundedRectangle(cornerRadius: 10)
-                                .fill(Color.darkNavy)
+                                .fill(Color("primary"))
                                 .opacity(viewModel.userId.isEmpty || viewModel.password.isEmpty ? 0.1 : 1)
                         )
                 }
@@ -97,7 +106,7 @@ struct LoginView: View {
                 .padding(.top, 20)
                 
                 // 회원가입 및 아이디 찾기 버튼
-                HStack(spacing: 12) {
+                HStack(spacing: 30) {
                     Button("회원가입") {
                         showSignup = true
                     }
@@ -106,8 +115,8 @@ struct LoginView: View {
                         showFindIdView = true
                     }
                 }
-                .font(.custom("GmarketSansMedium", size: 13))
-                .tint(.gray)
+                .font(.custom("GmarketSansLight", size: 13))
+                .tint(Color("darkNavy"))
                 .padding(.top, 15)
                 
                 Spacer()
@@ -118,6 +127,7 @@ struct LoginView: View {
         }
         .scrollDismissesKeyboard(.immediately)
         .ignoresSafeArea(.keyboard)
+        .background(Color("bg"))
         .sheet(isPresented: $showFindIdView, content: {
             FindIDView()
                 .presentationDetents([.height(300)])

--- a/ToMyongJi.xcodeproj/project.pbxproj
+++ b/ToMyongJi.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		090BC95C2E939D90B1235265 /* ReceiptViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D9520AF5D1EAD72883699C0 /* ReceiptViewModelTests.swift */; };
 		0AF567CE918C4EF6271CFF3A /* AuthenticationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB662513BB59FD2768462EAE /* AuthenticationManagerTests.swift */; };
 		0C25B2422E51F0AE005E7308 /* OCRReceiptFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C25B2412E51F0AE005E7308 /* OCRReceiptFormView.swift */; };
+		0C3F71342E680C6000403D6E /* DismissButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C3F71332E680C6000403D6E /* DismissButton.swift */; };
 		11BB9F7835F838BBCB96EEAB /* InputPasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29452F0FF0CF6C327447CFB0 /* InputPasswordView.swift */; };
 		126E493559D72CC2C15F357A /* Receipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7484C47FE8D12F7E95F24DC6 /* Receipt.swift */; };
 		15AC8737B62235755ED0D214 /* SignUpEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E04969DDCC77A17FF2EE0EBC /* SignUpEndpoint.swift */; };
@@ -284,6 +285,7 @@
 		088C270FEB0EF9F0D1AEF376 /* AlamofireNetworkingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireNetworkingManager.swift; sourceTree = "<group>"; };
 		0BAD61A4B69A7EEF15E6F691 /* View+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extensions.swift"; sourceTree = "<group>"; };
 		0C25B2412E51F0AE005E7308 /* OCRReceiptFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRReceiptFormView.swift; sourceTree = "<group>"; };
+		0C3F71332E680C6000403D6E /* DismissButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissButton.swift; sourceTree = "<group>"; };
 		0D8F38D566B41009DB0E68B4 /* AdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminView.swift; sourceTree = "<group>"; };
 		0E546E5157879AFE739DA333 /* InputIDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputIDView.swift; sourceTree = "<group>"; };
 		0F128A6926E433DE37C8314F /* SignUpTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpTextField.swift; sourceTree = "<group>"; };
@@ -850,6 +852,7 @@
 			children = (
 				5DBFAD8D70C6358B8A1B957E /* CustomTF.swift */,
 				E9496419038EE7CD9CF6E9F4 /* GradientButton.swift */,
+				0C3F71332E680C6000403D6E /* DismissButton.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1546,6 +1549,7 @@
 				7136F22987457DAB7B39401D /* CustomTF.swift in Sources */,
 				B1A81BC8B44860D29B1EFC4B /* GradientButton.swift in Sources */,
 				2C4C2FD804A38F1E815CBDE7 /* Color+Extensions.swift in Sources */,
+				0C3F71342E680C6000403D6E /* DismissButton.swift in Sources */,
 				DADCF523967B11CF4130BBB5 /* View+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/UI/Resources/Assets.xcassets/gray_20.colorset/Contents.json
+++ b/UI/Resources/Assets.xcassets/gray_20.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF1",
+          "green" : "0xD7",
+          "red" : "0xCF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF1",
+          "green" : "0xD7",
+          "red" : "0xCF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UI/Resources/Assets.xcassets/gray_90.colorset/Contents.json
+++ b/UI/Resources/Assets.xcassets/gray_90.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x72",
+          "green" : "0x57",
+          "red" : "0x52"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x72",
+          "green" : "0x57",
+          "red" : "0x52"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UI/Resources/Assets.xcassets/primary.colorset/Contents.json
+++ b/UI/Resources/Assets.xcassets/primary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xAA",
+          "red" : "0x87"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xAA",
+          "red" : "0x87"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UI/Sources/Components/DismissButton.swift
+++ b/UI/Sources/Components/DismissButton.swift
@@ -1,0 +1,23 @@
+//
+//  DismissButton.swift
+//  UI
+//
+//  Created by JunnKyuu on 9/3/25.
+//  Copyright © 2025 ToMyongJi. All rights reserved.
+//
+
+import SwiftUI
+
+public struct DismissButton: View {
+    public init() {}
+    
+    public var body: some View {
+        Image(systemName: "chevron.left")
+            .font(.title2.weight(.medium))
+            .foregroundStyle(Color("gray_90"))
+    }
+}
+
+#Preview {
+    DismissButton()
+}


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

### 📝작업 내용

> ui: 로그인 뷰 디자인 개선
- asset에 색상 추가
- DismissButton 컴포넌트 생성

### 🔨테스트 결과 > 스크린샷 (선택)

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-03 at 16 16 06" src="https://github.com/user-attachments/assets/de13b1d8-5a1c-43bc-b8ee-ff680a27e35d" />


> 테스트 결과나 스크린 샷으로 보여줘야하는 부분을 삽입해주세요,
### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

