### PR TITLE
ui: 아이디 찾기 뷰 디자인 개선

### DIFF
--- a/App/Sources/SplashScreenView.swift
+++ b/App/Sources/SplashScreenView.swift
@@ -29,7 +29,7 @@ struct SplashScreenView: View {
                 .padding(.vertical, 230)
                 Spacer()
                 Text("To MyongJi - 명지대 학생들에게")
-                    .font(.custom("GmarketSansLight", size: 15))
+                    .font(.custom("GmarketSansLight", size: 14))
                     .foregroundStyle(Color("darkNavy"))
                     .padding(.bottom, 30)
             }

--- a/Feature/Sources/FindID/Views/FindIDView.swift
+++ b/Feature/Sources/FindID/Views/FindIDView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UI
 
 struct FindIDView: View {
     @Environment(\.dismiss) private var dismiss
@@ -14,29 +15,19 @@ struct FindIDView: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 15) {
-            Button {
-                dismiss()
-            } label: {
-                Image(systemName: "chevron.left")
-                    .font(.title3.bold())
-                    .foregroundStyle(Color.gray)
-                    .contentShape(.rect)
-            }
-            .padding(.top, 10)
-            
             Text("아이디 찾기")
-                .font(.custom("GmarketSansBold", size: 25))
+                .font(.custom("GmarketSansBold", size: 22))
                 .padding(.top, 5)
             
             Text("회원가입할 때 입력한 이메일 주소를 입력해주세요.")
-                .font(.custom("GmarketSansLight", size: 12))
-                .foregroundStyle(.gray)
+                .font(.custom("GmarketSansLight", size: 14))
+                .foregroundStyle(Color("gray_70"))
                 .padding(.top, -5)
             
             // 입력 필드를 감싸는 카드 뷰
             VStack(spacing: 0) {
                 TextField("이메일 주소", text: $viewModel.email)
-                    .font(.custom("GmarketSansLight", size: 15))
+                    .font(.custom("GmarketSansLight", size: 14))
                     .padding()
                     .focused($isFocused)
                     .submitLabel(.done)
@@ -46,8 +37,12 @@ struct FindIDView: View {
                         viewModel.findID()
                     }
             }
-            .background(Color.gray.opacity(0.1))
+            .background(Color.white)
             .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                .stroke(Color("gray_20"), lineWidth: 1)
+            )
             .padding(.top, 20)
             
             // 아이디 찾기 버튼
@@ -61,7 +56,7 @@ struct FindIDView: View {
                     .padding(.vertical, 15)
                     .background(
                         RoundedRectangle(cornerRadius: 10)
-                            .fill(Color.darkNavy)
+                            .fill(Color("primary"))
                             .opacity(viewModel.email.isEmpty ? 0.5 : 1)
                     )
             }
@@ -79,7 +74,8 @@ struct FindIDView: View {
         } message: {
             Text(viewModel.isSuccess ? "아이디: \(viewModel.userID)" : viewModel.alertMessage)
         }
-        .interactiveDismissDisabled()
+        // 스와이프로 내릴 수 있게 추가
+        .presentationDragIndicator(.visible)
     }
 }
 

--- a/Feature/Sources/Login/Views/LoginView.swift
+++ b/Feature/Sources/Login/Views/LoginView.swift
@@ -26,14 +26,7 @@ struct LoginView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 20) {
-                Button(action: {
-                    dismiss()
-                    if UserDefaults.standard.value(forKey: "selectedTab") as? Int != nil {
-                        UserDefaults.standard.set(1, forKey: "selectedTab")
-                    }
-                }) {
-                    DismissButton()
-                }
+                DismissButton()
                 .frame(maxWidth: .infinity, alignment: .leading)
                 
                 Spacer()
@@ -50,7 +43,7 @@ struct LoginView: View {
                 VStack(spacing: 10) {
                     // 아이디 입력
                     TextField("아이디", text: $viewModel.userId)
-                        .font(.custom("GmarketSansLight", size: 15))
+                        .font(.custom("GmarketSansLight", size: 14))
                         .padding()
                         .background(Color.white)
                         .clipShape(
@@ -70,7 +63,7 @@ struct LoginView: View {
                         
                     // 비밀번호 입력
                     SecureField("비밀번호", text: $viewModel.password)
-                        .font(.custom("GmarketSansLight", size: 15))
+                        .font(.custom("GmarketSansLight", size: 14))
                         .padding()
                         .background(Color.white)
                         .clipShape(RoundedRectangle(cornerRadius: 10))
@@ -115,7 +108,7 @@ struct LoginView: View {
                         showFindIdView = true
                     }
                 }
-                .font(.custom("GmarketSansLight", size: 13))
+                .font(.custom("GmarketSansLight", size: 12))
                 .tint(Color("darkNavy"))
                 .padding(.top, 15)
                 

--- a/UI/Resources/Assets.xcassets/gray_70.colorset/Contents.json
+++ b/UI/Resources/Assets.xcassets/gray_70.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC2",
+          "green" : "0xA0",
+          "red" : "0x97"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC2",
+          "green" : "0xA0",
+          "red" : "0x97"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UI/Sources/Components/DismissButton.swift
+++ b/UI/Sources/Components/DismissButton.swift
@@ -9,12 +9,20 @@
 import SwiftUI
 
 public struct DismissButton: View {
+    @Environment(\.dismiss) public var dismiss
     public init() {}
     
     public var body: some View {
-        Image(systemName: "chevron.left")
-            .font(.title2.weight(.medium))
-            .foregroundStyle(Color("gray_90"))
+        Button(action: {
+            dismiss()
+            if UserDefaults.standard.value(forKey: "selectedTab") as? Int != nil {
+                UserDefaults.standard.set(1, forKey: "selectedTab")
+            }
+        }) {
+            Image(systemName: "chevron.left")
+                .font(.title2.weight(.medium))
+                .foregroundStyle(Color("gray_90"))
+        }
     }
 }
 


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

### 📝작업 내용

> ui: 아이디 찾기 뷰 디자인 개선
- 폰트 크기 변경
- 배경 및 폰트 색상 변경
- 스와이프 제스처를 위한 dismiss 버튼 제거 및 .presentationDragIndicator(.visible) 추가

### 🔨테스트 결과 > 스크린샷 (선택)

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-03 at 16 39 33" src="https://github.com/user-attachments/assets/6ed02f71-0af3-40cb-be81-980ede22548d" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-03 at 16 39 44" src="https://github.com/user-attachments/assets/4bec1705-e2b7-47e1-9d89-3f092927a39f" />


> 테스트 결과나 스크린 샷으로 보여줘야하는 부분을 삽입해주세요,
### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

