### PR TITLE
ui: 영수증 조회 디자인 개선

### DIFF
--- a/Feature/Sources/Main/Views/MainTabView.swift
+++ b/Feature/Sources/Main/Views/MainTabView.swift
@@ -26,7 +26,7 @@ public struct MainTabView: View {
             AdminTabView()
         } else {
             ZStack(alignment: .bottom) {
-                // Main Content
+                // MARK: - Main Content
                 VStack {
                     switch selectedTab {
                     case 1:
@@ -43,7 +43,6 @@ public struct MainTabView: View {
                 }
                 .padding(.bottom, tabBarHeight)
                 
-                // Custom Tab Bar
                 customTabBar
             }
             .edgesIgnoringSafeArea(.bottom)

--- a/Feature/Sources/Receipts/Views/MonthPickerView.swift
+++ b/Feature/Sources/Receipts/Views/MonthPickerView.swift
@@ -30,7 +30,7 @@ struct MonthPickerView: View {
                 .padding()
             
             VStack(spacing: 20) {
-                // 월 선택
+                // MARK: - 월 선택
                 VStack(alignment: .leading, spacing: 10) {
                     LazyVGrid(columns: [
                         GridItem(.flexible()),
@@ -57,6 +57,7 @@ struct MonthPickerView: View {
                 
                 Spacer()
                 
+                // MARK: - 확인 버튼
                 Button {
                     onConfirm(localSelectedMonth)
                 } label: {
@@ -75,6 +76,7 @@ struct MonthPickerView: View {
     }
 }
 
+// MARK: - Preview
 #Preview {
     MonthPickerView(initialMonth: 3) { month in
         print("Confirmed month: \(month)")

--- a/Feature/Sources/Receipts/Views/ReceiptListView.swift
+++ b/Feature/Sources/Receipts/Views/ReceiptListView.swift
@@ -23,7 +23,7 @@ struct ReceiptListView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            // 상단 고정 영역
+            // MARK: - 상단 고정 영역
             VStack(spacing: 15) {
                 VStack(spacing: 20) {
                     Text(club.studentClubName)
@@ -31,9 +31,10 @@ struct ReceiptListView: View {
                         .foregroundStyle(Color.black)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     
+                    // MARK: - 인증 마크 및 월별 선택 버튼
                     HStack {
-                        // 토스 인증 마크 표시
                         if club.verification {
+                            // 토스 인증 마크
                             HStack {
                                 Image("toss_logo")
                                     .resizable()
@@ -49,18 +50,7 @@ struct ReceiptListView: View {
 
                         }
                         
-                        // 조회 버튼
-//                        Menu {
-//                            Button {
-//                                showingMonthPicker = true
-//                            } label: {
-//                                HStack {
-//                                    Text("월별 선택")
-//                                    if viewModel.isFiltered {
-//                                        Image(systemName: "checkmark")
-//                                    }
-//                                }
-//                            }
+                        // 월별 선택 버튼
                         Button {
                             showingMonthPicker = true
                         } label: {
@@ -72,7 +62,6 @@ struct ReceiptListView: View {
                             .foregroundStyle(Color("gray_70"))
                         }
                         .frame(maxWidth: .infinity, alignment: .trailing)
-                        .padding(.horizontal, 15)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     
@@ -82,15 +71,17 @@ struct ReceiptListView: View {
             }
             .padding(.vertical, 10)
             
-            // 스크롤 영역
+            // MARK: - 스크롤 영역
             ScrollView(.vertical) {
-                LazyVStack(spacing: 15) {
+                LazyVStack(spacing: 30) {
                     ForEach(viewModel.filteredReceipts) { receipt in
                         ClubReceiptView(receipt)
                     }
                 }
+                .padding(.vertical, 20)
+                .background(RoundedRectangle(cornerRadius: 10).fill(Color.white))
                 .padding(.horizontal, 15)
-                .padding(.top, 10)
+                .padding(.vertical, 20)
             }
             .background(Color("signup-bg"))
             .scrollDisabled(false)
@@ -108,11 +99,12 @@ struct ReceiptListView: View {
                 ProgressView()
             }
         }
+        // MARK: - 월별 선택 시트
         .sheet(isPresented: $showingMonthPicker) {
             MonthPickerView(
                 initialMonth: viewModel.selectedMonth
             ) { selectedMonth in
-                if selectedMonth == 13 { // "전체"가 13번째 항목
+                if selectedMonth == 13 {
                     viewModel.updateFilter(isFiltered: false)
                 } else {
                     viewModel.updateFilter(isFiltered: true, month: selectedMonth)
@@ -127,49 +119,50 @@ struct ReceiptListView: View {
         .onAppear {
             viewModel.getReceipts(studentClubId: club.studentClubId)
         }
-        .id(club.studentClubId) // 뷰의 ID를 고정하여 불필요한 재생성을 방지
+        .id(club.studentClubId) // 클럽 변경 시 뷰 새로고침
     }
     
-    
+    // MARK: - 배경 위치 조정
     func backgroundLimitOffset(_ proxy: GeometryProxy) -> CGFloat {
         let minY = proxy.frame(in: .scrollView).minY
         
         return minY < 100 ? -minY + 100 : 0
     }
     
-    // Club Receipt View
+    // MARK: - 영수증 뷰
     @ViewBuilder
     func ClubReceiptView(_ receipt: Receipt) -> some View {
         HStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 4, content: {
                 Text(receipt.content)
-                    .font(.custom("GmarketSansBold", size: 14))
-                    .foregroundStyle(Color.darkNavy)
+                    .font(.custom("GmarketSansMedium", size: 14))
+                    .foregroundStyle(Color.black)
                 
                 Text(receipt.date)
                     .font(.custom("GmarketSansMedium", size: 12))
-                    .foregroundStyle(.gray)
+                    .foregroundStyle(Color("gray_70"))
             })
             
             Spacer(minLength: 0)
             
             if receipt.deposit != 0 {
                 Text("+ \(receipt.deposit)")
-                    .font(.custom("GmarketSansBold", size: 14))
-                    .foregroundStyle(Color.deposit)
+                    .font(.custom("GmarketSansMedium", size: 16))
+                    .foregroundStyle(Color("primary"))
             }
             
             if receipt.withdrawal != 0 {
                 Text("- \(receipt.withdrawal)")
-                    .font(.custom("GmarketSansBold", size: 14))
-                    .foregroundStyle(Color.withdrawal)
+                    .font(.custom("GmarketSansMedium", size: 14))
+                    .foregroundStyle(Color("error"))
             }
         }
         .padding(.horizontal, 15)
-        .padding(.vertical, 6)
+        .background(Color.white)
     }
 }
 
+// MARK: - Preview
 #Preview {
     ReceiptListView(club: Club(
         studentClubId: 1,


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

### 📝작업 내용

> ui: 영수증 조회 디자인 개선

### 🔨테스트 결과 > 스크린샷 (선택)

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-11 at 16 43 21" src="https://github.com/user-attachments/assets/3bf005e1-13ce-49b9-8222-7a682b0ee0d5" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-11 at 16 43 27" src="https://github.com/user-attachments/assets/17a6f090-1488-4572-ab55-89bde2527e6d" />


> 테스트 결과나 스크린 샷으로 보여줘야하는 부분을 삽입해주세요,
### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

